### PR TITLE
Tooltip issue in comment on hover fixed

### DIFF
--- a/modules/lsfilter/src/js/LSFilterInputWindow.js
+++ b/modules/lsfilter/src/js/LSFilterInputWindow.js
@@ -19,4 +19,7 @@ $().ready(function() {
 			return false;
 		}
 	});
+	$(document).on("hover", "#filter_result table td a span", function() {
+		$(this).removeAttr("title");
+	});
 });


### PR DESCRIPTION
Listview on hover comment-icon, title attribute "Comments" covers some of the
information of the comment.
Removed title attribute on comment-icon hover.

This fixes MON-11538
Signed-off-by: Ramesh T ramesht@op5.com