### PR TITLE
Remove title attribute for comment-icon on hover

### DIFF
--- a/modules/lsfilter/src/js/LSFilterInputWindow.js
+++ b/modules/lsfilter/src/js/LSFilterInputWindow.js
@@ -19,7 +19,7 @@ $().ready(function() {
 			return false;
 		}
 	});
-	$(document).on("hover", "#filter_result table td a span", function() {
+	$(document).on("hover", "#filter_result table td a span.x16-add-comment", function() {
 		$(this).removeAttr("title");
 	});
 });


### PR DESCRIPTION
Previously title attribute was removed for all icon's in listview on hover.
Now we removed title attribute only for comment icon on hover.

This fixes MON-11538
Signed-off-by: Ramesh T ramesht@op5.com