### PR TITLE
Fix too wide margin at top when nachos banner is not shown

### DIFF
--- a/modules/lsfilter/src/js/LSFilterList.js
+++ b/modules/lsfilter/src/js/LSFilterList.js
@@ -643,7 +643,7 @@ function lsfilter_list(config)
             header.remove();
         }
 
-        if(!currentLocation.includes('hosts')) {
+        if(currentLocation.indexOf('hosts') === -1) {
             $('div#nachos-page-banners').css('margin', '0px 0px');
         }
     }

--- a/modules/lsfilter/src/js/LSFilterList.js
+++ b/modules/lsfilter/src/js/LSFilterList.js
@@ -632,17 +632,19 @@ function lsfilter_list(config)
 	};
 
 	this.banner_in_listview = function()
-	{
-		if($('div#nachos-page-banners').length > 0) {
-			var thead =  $(this.config.table).find('thead');
-			var header = $(thead).filter(function(){return !$(this).hasClass('floating-header');});
-			var banner = $('div#nachos-page-banners');
-			if(self.request_query.indexOf('recurring_downtimes') == -1){
-				banner.css('margin', '25px 0 3px 0');
-				header.remove();
-			}else{
-				banner.css('margin', '0px 0 3px 0');
-			}
-		}
-	}
+    {
+        var currentLocation = window.location.href.toString();
+
+        if($('div#nachos-page-banners').length > 0) {
+            var thead =  $(this.config.table).find('thead');
+            var header = $(thead).filter(function(){return !$(this).hasClass('floating-header');});
+            var banner = $('div#nachos-page-banners');
+            banner.css('margin', '25px 0 3px 0');
+            header.remove();
+        }
+
+        if(!currentLocation.includes('hosts')) {
+            $('div#nachos-page-banners').css('margin', '0px 0px');
+        }
+    }
 }

--- a/modules/lsfilter/src/js/LSFilterList.js
+++ b/modules/lsfilter/src/js/LSFilterList.js
@@ -640,11 +640,11 @@ function lsfilter_list(config)
             var header = $(thead).filter(function(){return !$(this).hasClass('floating-header');});
             var banner = $('div#nachos-page-banners');
             banner.css('margin', '25px 0 3px 0');
-            header.remove();
-        }
-
-        if(currentLocation.indexOf('hosts') === -1) {
-            $('div#nachos-page-banners').css('margin', '0px 0px');
+			header.remove();
+			
+			if(currentLocation.indexOf('hosts') === -1) {
+				banner.css('margin', '0px 0px');
+			}
         }
     }
 }


### PR DESCRIPTION
This commit ensures that when nachos banner is not shown the margin at top won't be too wide at dashboard.

This fixes MON-11558

Signed-off by: Adrián Villalba <avillalba@itrsgroup.com>