### PR TITLE
Disable the recurring downtime summary

### DIFF
--- a/modules/monitoring/views/recurring_downtime/js/recurring_downtime.js
+++ b/modules/monitoring/views/recurring_downtime/js/recurring_downtime.js
@@ -736,6 +736,8 @@ $(document).ready(function() {
 });
 
 function summary_show(){
+  return; // Don't render the summary.
+
   var flexible = $('#fixed').attr('checked');
   var start_time = $('#fixed-duration-start-time').val();
   var end_time = $('#fixed-duration-end-time').val();


### PR DESCRIPTION
This will disable/not show the summary inside the recurring downtime item view.
