### PR TITLE
Make pluck_recurrence compatible with the legacy recurrence_on format

### DIFF
--- a/modules/monitoring/includes/downtime.php
+++ b/modules/monitoring/includes/downtime.php
@@ -394,11 +394,21 @@ class RecurringDowntime extends Downtime {
 	 */
 	public function pluck_recurrence($key) {
 		$plucked = array();
-		foreach($this->recurrence_on as $item) {
-			if(!array_key_exists($key, $item)) {
-				continue;
+		$on = $this->recurrence_on;
+
+		// Check if `recurrence_on` is an associative array (legacy format).
+		if(array_keys($on) !== range(0, count($on) - 1)) {
+			// Legacy format: check if the given key exists
+			if(array_key_exists($key, $on)) {
+				array_push($plucked, $this->recurrence_on[$key]);
 			}
-			array_push($plucked, $item[$key]);
+		} else {
+			// With the new format, objects are always contained in an array - iterate.
+			foreach ($on as $recurrence) {
+				if (array_key_exists($key, $recurrence)) {
+					array_push($plucked, $recurrence[$key]);
+				}
+			}
 		}
 		return $plucked;
 	}

--- a/test/DowntimeWeekTest.php
+++ b/test/DowntimeWeekTest.php
@@ -43,6 +43,31 @@ class Downtime_Week_Test extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * recurrence_on should work with single items not contained in an array
+	 * @group recurring_downtime
+	 */
+	public function test_legacy_recurrence_on() {
+		$mock = new DowntimeModel();
+		$mock->set_start('2019-04-10');
+		$mock->recurrence = array(
+			'label' => 'custom',
+			'no' => '1',
+			'text' => 'week'
+		);
+		$mock->recurrence_on = array('day' => WEDNESDAY);
+		$schedule = new RecurringDowntime($mock);
+
+		$dow_output = $schedule->pluck_recurrence(DAY);
+		$this->assertFalse(in_array(MONDAY, $dow_output));
+		$this->assertFalse(in_array(TUESDAY, $dow_output));
+		$this->assertTrue(in_array($schedule->start->get_day_of_week(), $dow_output)); // WEDNESDAY
+		$this->assertFalse(in_array(THURSDAY, $dow_output));
+		$this->assertFalse(in_array(FRIDAY, $dow_output));
+		$this->assertFalse(in_array(SATURDAY, $dow_output));
+		$this->assertFalse(in_array(SUNDAY, $dow_output));
+	}
+
+	/**
 	 * match_week_interval() should evaluate to false if the stepping does /not/ match
 	 * @group recurring_downtime
 	 */

--- a/test/includes/downtime.php
+++ b/test/includes/downtime.php
@@ -50,7 +50,8 @@ function mock_date($date_str) {
 }
 
 class DowntimeModel {
-	protected $recurrence = 0, $recurrence_on = 0;
+	public $recurrence = 0;
+	public $recurrence_on = 0;
 	public $recurrence_ends = "0";
 	public $duration;
 	public $start_date, $start_time;


### PR DESCRIPTION
With the new format, items are always contained in a sequential array, example:
[{"day": x}]

The old format does not use sequential arrays for single items, example:
{"day": x}

This will make pluck_recurrence() compatible with both.
