### PR TITLE
Fix undefined variable in validate_uri_string

### DIFF
--- a/application/controllers/ajax.php
+++ b/application/controllers/ajax.php
@@ -33,6 +33,7 @@ class Ajax_Controller extends Authenticated_Controller {
 			return $setting;
 		}
 		$setting_info = json_decode($setting, true);
+		$setting_href = array();
 		foreach ($setting_info as $setting_data) {
 			$href = htmlspecialchars($setting_data['href'], ENT_QUOTES, 'UTF-8');
 			$setting_href[] = array('href' => $href);


### PR DESCRIPTION
When $setting_info was an empty array, $setting_href would not be
initialized and then caused an undefined variable error later on.

This fixes MON-11594.

Signed-off-by: Petter Nyström <pnystrom@op5.com>