### PR TITLE
Help text flicker when hovering a help icon fixed

### DIFF
--- a/application/media/css/lib.popover.css
+++ b/application/media/css/lib.popover.css
@@ -9,6 +9,7 @@
   z-index: 9999;
   word-break: normal;
   word-wrap: normal;
+  pointer-events: none;
 }
 
 .lib-popover-load {


### PR DESCRIPTION
Previously help text that is supposed to appear when hovering a round help icon, it was flicker so we can't read it.
Now flicker issue on help icon hover is fixed, able to read it.

This fixes MON-11518
Signed-off-by: Ramesh T ramesht@op5.com