### PR TITLE
MON-11611 Scheduled reports created before 8.0.2 are no longer generated

### DIFF
--- a/modules/reports/models/scheduled_reports.php
+++ b/modules/reports/models/scheduled_reports.php
@@ -339,14 +339,16 @@ class Scheduled_reports_Model extends Model
 		$send_date = array();
 
 		$db = Database::instance();
-		$sql = "SELECT t1.*,t2.value AS timezone FROM scheduled_reports AS t1 INNER JOIN saved_reports_options AS t2 ON t1.report_id = t2.report_id WHERE t2.name = 'report_timezone'";
+		$sql = "SELECT t1.*,(SELECT value FROM saved_reports_options WHERE report_id = t1.report_id AND name = 'report_timezone') AS timezone FROM scheduled_reports AS t1";
 		$res = $db->query($sql);
 
 		foreach($res as $row){
 			$report_period = json_decode($row->report_period);
 			$report_time = $row->report_time;
 			$report_timezone = $row->timezone;
-			date_default_timezone_set( $report_timezone );
+			if($report_timezone != ''){
+				date_default_timezone_set( $report_timezone );
+			}
 
 			$repeat_no = $report_period->no;
 			$last_sent = $row->last_sent;


### PR DESCRIPTION
MON-11611 Scheduled reports created before 8.0.2 are no longer generated

Earlier there was some problem in generating old reports due to
timezone.

we changed the sql query to check timezone and scheduled report .