### PR TITLE
Decreased margin on product image in menu

### DIFF
--- a/application/views/css/layout.css
+++ b/application/views/css/layout.css
@@ -1684,6 +1684,7 @@ div#header div.main-menu img.brand-icon {
   height: 49px;
   margin-top: -9px;
   margin-left: -12px;
+  margin-right: -21px;
 }
 
 span.brand {


### PR DESCRIPTION
The product image in the menu had to much margin to the right. So that when you
hovered the image an area next right to the image became grey. With less right
margin this won't happen.

This is a part of MON-11626

Signed-off-by: Elin Linder <elinder@op5.com>