### PR TITLE
Bugfix/mon 11672 direct kb links in monitor gui broken since confluence migration

### DIFF
--- a/application/config/menu.php
+++ b/application/config/menu.php
@@ -1,4 +1,4 @@
 <?php defined('SYSPATH') OR die('No direct access allowed.');
 
 $config['items'] = false;
-$config['manual_url'] = 'https://kb.op5.com/display/DOC';
+$config['manual_url'] = 'https://docs.itrsgroup.com/';

--- a/application/controllers/user.php
+++ b/application/controllers/user.php
@@ -87,7 +87,7 @@ class User_Controller extends Authenticated_Controller {
 		);
 
 		$sub_headings = array(
-			'listview' => array("https://kb.op5.com/x/AwE6", _('Read specification online'))
+			'listview' => array("https://support.itrsgroup.com/hc/en-us/articles/360020258033-Customizing-listview-columns", _('Read specification online'))
 		);
 
 		$settings['pagination'] = array(

--- a/application/views/template_head.php
+++ b/application/views/template_head.php
@@ -49,7 +49,7 @@ if (!empty($base_href)) {
 						"message": "OP5 Monitor uses cookies to ensure you get the best browsing experience. If you continue to use our website you agree to our use of cookies.",
 						"dismiss": "Got it",
 						"link": "Learn More",
-						"href": "https://kb.op5.com/x/txNrAQ"
+						"href": "https://support.itrsgroup.com/hc/en-us/articles/360020253933-Cookie-Policy"
 					},
 					onPopupOpen: function() { 
 						$('#content').append('<div id="extra_div_for_cookie" style="height:200px"></div>'); 

--- a/features/menu.feature
+++ b/features/menu.feature
@@ -68,7 +68,7 @@ Feature: Menu
 	@unreliable_el7 @unreliable
 	Scenario: Verify that the Manual link goes to the KB
 		When I hover the branding
-		Then I should see css "a[href='https://kb.op5.com/display/DOC']"
+		Then I should see css "a[href='https://docs.itrsgroup.com/']"
 
 	Scenario: Validate quicklink absolute URL
 		When I click "Manage quickbar"

--- a/modules/lsfilter/libraries/LSFilterSetBuilderVisitor.php
+++ b/modules/lsfilter/libraries/LSFilterSetBuilderVisitor.php
@@ -271,7 +271,7 @@ class LSFilterSetBuilderVisitor extends LSFilterVisitor {
 			case 'date':
 				$ret = strtotime($arg_list2[0]);
 				if (false === $ret) {
-					throw new ORMException("Don't know how to translate \"" . htmlspecialchars($arg_list2[0]) . "\" into a date, please <a href=\"https://kb.op5.com/x/jIWX\" target=\"blank\">click here</a> for information on supported date formats.");
+					throw new ORMException("Don't know how to translate \"" . htmlspecialchars($arg_list2[0]) . "\" into a date, please <a href=\"https://support.itrsgroup.com/hc/en-us/articles/360020061894-Listview-filter-date-function\" target=\"blank\">click here</a> for information on supported date formats.");
 				}
 				return $ret;
 				break;

--- a/test/backup_Test.php
+++ b/test/backup_Test.php
@@ -2,7 +2,7 @@
 /**
  * Test the backup functions that are reached through the GUI. There are other
  * types of backups being run too, you can read more about backups here:
- * https://kb.op5.com/dosearchsite.action?queryString=backup
+ * https://support.itrsgroup.com/hc/search?query=backup
  */
 class Backup_Test extends PHPUnit_Framework_TestCase {
 


### PR DESCRIPTION
Seperate commits for readability, will of course squash them when merging.