### PR TITLE
Reduce scrolling after multiaction

### DIFF
--- a/modules/monitoring/models/naemonobject.php
+++ b/modules/monitoring/models/naemonobject.php
@@ -50,7 +50,7 @@ class NaemonObject_Model extends Object_Model {
 		}
 		return array(
 			'status' => $result,
-			'output' => $output=="OK" ? sprintf(_('Your command was successfully submitted to %s.'), Kohana::config('config.product_name')) : $output
+			'output' => $output=="OK" ? sprintf(_('Your commands were successfully submitted to %s.'), Kohana::config('config.product_name')) : $output
 		);
 	}
 }

--- a/modules/monitoring/views/monitoring/naemon_command.php
+++ b/modules/monitoring/views/monitoring/naemon_command.php
@@ -1,11 +1,23 @@
+<script>
+$(document).ready(function(){
+	var counter = 0; // Declare counter. This variable count the total number of alerts.
+  	$(".alert").each(function(){
+		counter++;
+		// If counter is equal one, the alert will be displayed. 
+		if(counter === 1) {
+			$(this).css("display", "block");
+		} 
+	});
+});
+</script>
+
 <?php
-print "<h2>" . $object->get_readable_name() . "</h2>";
 if ($result['status']) {
-	echo '<div class="alert notice">'.html::specialchars($result['output']);
+	echo '<div class="alert notice" style="display: none;">'.html::specialchars($result['output']);
 	echo "</div>\n";
 	$this->footer = '<input style="margin-left: 12px" type="button" value="Done" onclick="history.go(-2)" />'."\n";
 } else {
-	echo '<div class="alert error">'.sprintf(_('There was an error submitting your command to %s.'), Kohana::config('config.product_name'));
+	echo '<div class="alert error" style="display: none;">'.sprintf(_('There was an error submitting your commands to %s.'), Kohana::config('config.product_name'));
 	if (!empty($result['output'])) {
 		echo '<br /><br />'._('ERROR').': '.html::specialchars($result['output']);
 	}


### PR DESCRIPTION
This commit reduce the number of alerts after multiaction.

This ensures that only a general alert will be displayed and not one alert for each host.

This fixes MON-11665.

Signed-off-by: Adrián Villalba <avillalba@itrsgroup.com>