### PR TITLE
Apply recurring downtimes on Sundays

### DIFF
--- a/modules/monitoring/includes/datetime.php
+++ b/modules/monitoring/includes/datetime.php
@@ -48,12 +48,13 @@ class NinjaDateTime extends DateTime {
 	}
 
 	/**
-	 * Get current day of week (1-7)
+	 * Get current day of week (0-6)
 	 *
 	 * @return int
 	 */
 	public function get_day_of_week() {
-		return (int)$this->format('N');
+		$day_number = (int)$this->format('N');
+		return $day_number === 7 ? 0 : $day_number;
 	}
 
 	/**

--- a/test/DowntimeWeekTest.php
+++ b/test/DowntimeWeekTest.php
@@ -128,4 +128,21 @@ class Downtime_Week_Test extends PHPUnit_Framework_TestCase {
 		$result = $schedule->pluck_recurrence('UNKNOWN_UNIT');
 		$this->assertEquals(array(), $result);
 	}
+
+	/**
+	 * Test case for recurring downtimes scheduled on a Sunday
+	 * @group recurring_downtime
+	 */
+	public function test_recurring_sunday() {
+		$mock = get_week_mock(1, array(SUNDAY));
+		$mock->set_start('2019-01-01 11:55');
+		$mock->set_end('2019-01-01 13:00');
+		$schedule = new RecurringDowntime($mock);
+		$input = mock_date('2019-05-26');
+		// Match week
+		$this->assertTrue($schedule->match_week_interval($input));
+		// Match day
+		$days = $schedule->pluck_recurrence('day');
+		$this->assertTrue(in_array($input->get_day_of_week(), $days));
+	}
 }


### PR DESCRIPTION
NinjaDateTime uses ISO 8691 to express dates and time, with week days
numbered as 1-7, 7 being Sunday. While the input data uses the North
American/Islamic system which numbers week days as 0-6, 0 being Sunday.
This caused recurring downtimes scheduled on a Sunday to fail, while all
other week days worked correctly. With this commit the function which
returns the day of the week is updated to use the 0-6 format.

Fixes: MON-11684

Signed-off-by: Erik Sjöström <esjostrom@op5.com>