### PR TITLE
ninja: Add logrotate funtionality

### DIFF
--- a/op5build/monitor-ninja.logrotate
+++ b/op5build/monitor-ninja.logrotate
@@ -1,0 +1,11 @@
+/var/log/op5/ninja.log {
+    su apache apache
+    weekly
+    rotate 10
+    compress
+    dateext
+    dateformat -%Y%m%d
+    missingok
+    notifempty
+    create 0664 apache apache
+}

--- a/op5build/monitor-ninja.spec
+++ b/op5build/monitor-ninja.spec
@@ -151,6 +151,8 @@ find %buildroot -type d -print0 | xargs -0 chmod a+x
 mkdir -p %buildroot/etc/cron.d/
 install -m 644 install_scripts/scheduled_reports.crontab %buildroot/etc/cron.d/scheduled-reports
 install -m 644 install_scripts/recurring_downtime.crontab %buildroot/etc/cron.d/recurring-downtime
+install -d %buildroot%_sysconfdir/logrotate.d
+install -pm 0644 op5build/monitor-ninja.logrotate %{buildroot}%_sysconfdir/logrotate.d/monitor-ninja
 
 # executables
 for f in cli-helpers/apr_md5_validate \
@@ -232,6 +234,7 @@ sed -i 's/expose_php = .*/expose_php = off/g' /etc/php.ini
 %dir /var/log/op5/ninja
 
 %attr(640,%daemon_user,%daemon_group) %prefix/application/config/database.php
+%config %attr(644,root, root) %_sysconfdir/logrotate.d/monitor-ninja
 
 %phpdir/op5
 %exclude %phpdir/op5/ninja_sdk


### PR DESCRIPTION
ninja logs and few files inside ninja folder
currently do not have any logrotate funtionality.
As a result the file grows rapidly over a period of time.
This fix addresses this issue by adding logrotate option.

MON-11668

Signed-off by:sbhapur@op5.com