### PR TITLE
Removing password-helper height declaration

### DIFF
--- a/application/views/css/form.css
+++ b/application/views/css/form.css
@@ -146,7 +146,6 @@ form.renderable-login fieldset label[for="password-repeat"]{
 
 form.renderable-login .password-helper {
 	background-color: rgb(254, 244, 229);
-	height: 35px;
 	width: 275px;
 	border-bottom: 2px solid orange;
 	margin: 0 auto;


### PR DESCRIPTION
This element should not have a static height, as this will mess up
a message that is longer and requires the box to expand downwards.