### PR TITLE
Removing password-helper height declaration

### DIFF
--- a/application/views/css/form.css
+++ b/application/views/css/form.css
@@ -146,7 +146,6 @@ form.renderable-login fieldset label[for="password-repeat"]{
 
 form.renderable-login .password-helper {
 	background-color: rgb(254, 244, 229);
-	height: 35px;
 	width: 275px;
 	border-bottom: 2px solid orange;
 	margin: 0 auto;


### PR DESCRIPTION
When creating the initial admin account in Monitor, this style
is used for a message telling the user that admin credentials
cannot be recovered.

This element should not have a static height, as this will cause
a message that is longer to overflow outside of the div.

Instead, no height should mean that the box to expands downwards
as more text is added.

This fixes: MON-11748
"Text overflow when creating admin account on fresh install"