### PR TITLE
Rename label to "Runtime options" and add tooltip

### DIFF
--- a/application/controllers/search.php
+++ b/application/controllers/search.php
@@ -303,7 +303,9 @@ class Search_Controller extends Ninja_Controller {
 			To temporarily change this for your search, use limit=&lt;number&gt; (e.g limit=100) or limit=0 to disable the limit entirely."), config::get('pagination.default.items_per_page')
 		),
 		'saved_search_help' => _('Click to save this search for later use. Your saved searches will be available by clicking on the icon just below the search field at the top of the page.'),
-		'filterbox' => _('When you start to type, the visible content gets filtered immediately.<br /><br />If you press <kbd>enter</kbd> or the button "Search through all result pages", you filter all result pages but <strong>only through its primary column</strong> (<em>host name</em> for host objects, etc).')
+		'filterbox' => _('When you start to type, the visible content gets filtered immediately.<br /><br />If you press <kbd>enter</kbd> or the button "Search through all result pages", you filter all result pages but <strong>only through its primary column</strong> (<em>host name</em> for host objects, etc).'),
+		'runtime_options' => _('<div class="runtime-options-tooltip-text"><p>The settings are reset at restart.</p> <p>To make persistent changes, go<p/> to the configuration page.</div>')
+
 		);
 		if (array_key_exists($id, $helptexts)) {
 			echo $helptexts[$id];

--- a/modules/monitoring/views/extinfo/components/operating.php
+++ b/modules/monitoring/views/extinfo/components/operating.php
@@ -1,11 +1,12 @@
 <div class="information-component">
-	<div class="information-component-title">Operating status</div>
+	<div class="information-component-title">
+		Runtime options
+		<a class="help-icon runtime-options-icon" style="background: url('/monitor/application/views/icons/16x16/question-mark.png')" data-popover="help:search.runtime_options"></a>
+	</div>
 <?php
-
 $toggle = View::factory('extinfo/components/toggle', array(
 	'object' => $object
 ));
-
 ?>
 <div class="information-cell-inline">
 <?php

--- a/modules/monitoring/views/extinfo/css/extinfo.css
+++ b/modules/monitoring/views/extinfo/css/extinfo.css
@@ -110,6 +110,16 @@ p {
 	margin: 8px 0 16px 0;
 }
 
+.runtime-options-icon {
+	margin-left: 10px;
+	margin-bottom: 3px;
+}
+
+.runtime-options-tooltip-text {
+	text-align: left;
+	font-size: 10pt;
+}
+
 .information-cell,
 .information-cell-inline {
 	display: inline-block;


### PR DESCRIPTION
This commit rename "Operating status" label to "Runtime options" and add a tooltip next to it.

This ensures the user is guided to persistent configuration.

This fixes MON-11030.

Signed-off-by: Adrián Villalba <avillalba@itrsgroup.com>