### PR TITLE
Remove nachos banners

### DIFF
--- a/application/views/css/layout.css
+++ b/application/views/css/layout.css
@@ -1185,6 +1185,33 @@ h1.emote b {
   color: #fff;
 }
 
+.info-notice {
+  width: 40%;
+  line-height: 2;
+  margin-bottom: 20px;
+  padding: 3px 8px 3px 30px;
+  border-radius: 0px !important;
+  color: black;
+}
+
+.info-notice-warning {
+  background: #fef4e5 url("../images/icons/shield-warning.png") no-repeat 8px 6px;
+  border-bottom: 2px solid #f99400;
+}
+.info-notice-information {
+  background: #e6f1f8 url("../images/icons/shield-info.png") no-repeat 8px 6px;
+  border-bottom: 2px solid #0176bd;
+  margin-top: 10px;
+}
+.info-notice-success {
+  background: #ecf8ec url("../icons/x16/shield-ok.png") no-repeat 8px 6px;
+  border-bottom: 2px solid #3fb93d;
+}
+.info-notice-error {
+  background: #fdebee url("../icons/x16/shield-critical.png") no-repeat 8px 6px;
+  border-bottom: 2px solid #ef3b4f;
+}
+
 .notify-notification-bar .notify-notification.pending,
 .alert.pending,
 .state-background.pending {


### PR DESCRIPTION
This ensures that reduce polling and load on Nachos API, Nachos banners has been removed from all pages, except the save configuration page. Banners have also been redesigned.

This fixes MON-11730.

Signed-off-by: Adrián Villalba <avillalba@itrsgroup.com>