### PR TITLE
Show more filters and dashboards in menu

### DIFF
--- a/modules/menu/views/menu.php
+++ b/modules/menu/views/menu.php
@@ -82,9 +82,14 @@
 		}
 
 		if ($menu->has_children()) {
+			$filterHeaderArray = array("all_hosts", "all_services", "all_hostgroups", "all_servicegroups");
 			$class = $style . '-menu';
 			$render .= "<ul class=\"$class\">";
 			foreach ($branch as $child) {
+				if(in_array($child->get_id(), $filterHeaderArray)) {
+					$render .= '<li tabindex="1" class="menu-separator">Filters</li>';
+				}
+
 				if (in_array($child->get_id(), $config)) { continue; }
 				$cAttributes = $child->get_attributes();
 				$render .= '<li tabindex="1">' . $render_menu($child, $style, false) . '</li>';

--- a/modules/monitoring/hooks/listview_menu_hook.php
+++ b/modules/monitoring/hooks/listview_menu_hook.php
@@ -29,7 +29,7 @@ Event::add ('ninja.menu.setup', function (){
 		$menu->set('Manage.Process information', 'extinfo/show_process_info', 6, 'icon-16 x16-info');
 	}
 
-	$max_filters = 6;
+	$max_filters = 14;
 
 	$menu->set('Manage.Manage filters', listview::querylink( '[saved_filters] all'), 3, 'icon-16 x16-eventlog');
 	$menu->set('Monitor.Network Outages', 'outages', null, 'icon-16 x16-outages');


### PR DESCRIPTION
Earlier, the list of filters and dashboards to show has been very
limited. With this update the number of filters shown has been increased
to 15 filters, for hosts, services, hostgroups and servicegroups.
Also, to these menu options there has been added a filter title.

This fixes MON-11604

Signed-off-by: Elin Linder <elinder@op5.com>