### PR TITLE
Add LMD dependency

### DIFF
--- a/op5build/monitor-ninja.spec
+++ b/op5build/monitor-ninja.spec
@@ -25,6 +25,7 @@ Requires: wkhtmltopdf
 Requires: op5-mysql
 Requires: op5-monitor-supported-webserver
 Requires: monitor-livestatus
+Requires: op5-lmd
 Requires: monitor-backup
 Requires: op5-bootstrap
 # Merlin creates our database
@@ -59,6 +60,7 @@ Group: op5/Monitor
 Requires: monitor-ninja = %version
 Requires: op5-naemon
 Requires: monitor-livestatus
+Requires: op5-lmd
 Requires: monitor-nagvis
 Requires: monitor-nacoma
 Requires: php-phpunit-PHPUnit
@@ -86,6 +88,7 @@ Group: op5/monitor
 Requires: op5-naemon
 Requires: monitor-merlin
 Requires: monitor-livestatus
+Requires: op5-lmd
 
 %description monitoring
 Provides ORM, bindings and interfaces for Livestatus, Naemon and queryhandler.


### PR DESCRIPTION
As of Monitor 8, livestatus queries are made against LMD. To ensure all
integration tests works correct, we add LMD as a dependency to the
package.

Note: merge after https://github.com/ITRS-Group/monitor-lmd/pull/21

Signed-off-by: Jacob Hansen <jhansen@op5.com>