### PR TITLE
Add LMD dependency

### DIFF
--- a/features/support/configuration.rb
+++ b/features/support/configuration.rb
@@ -318,7 +318,7 @@ module Configuration
       #We need to wait for the livestatus socket to disappear
       #since Nagios has not necessarily finished unloading all
       #brokers by the time it removes the pid file (above)
-      file_wait(File.join(@rw_path, "live"), :state=>:removed)
+      file_wait(File.join(@rw_path, "live_tmp"), :state=>:removed)
       `mysql -uroot nacoma -e 'TRUNCATE action_log'`# update timestamp so nacoma imports
       if cleanup_dirs
         FileUtils.rm_rf @root_path if File.exists? @root_path

--- a/op5build/monitor-ninja.spec
+++ b/op5build/monitor-ninja.spec
@@ -25,6 +25,7 @@ Requires: wkhtmltopdf
 Requires: op5-mysql
 Requires: op5-monitor-supported-webserver
 Requires: monitor-livestatus
+Requires: op5-lmd
 Requires: monitor-backup
 Requires: op5-bootstrap
 # Merlin creates our database
@@ -59,6 +60,7 @@ Group: op5/Monitor
 Requires: monitor-ninja = %version
 Requires: op5-naemon
 Requires: monitor-livestatus
+Requires: op5-lmd
 Requires: monitor-nagvis
 Requires: monitor-nacoma
 Requires: php-phpunit-PHPUnit
@@ -80,12 +82,20 @@ Requires: ruby-devel
 %description test
 Additional test files for ninja
 
+%post test
+%if 0%{?rhel} >= 7
+	systemctl start lmd
+%else
+	service lmd start
+%endif
+
 %package monitoring
 Summary: Naemon and Livestatus module for ninja
 Group: op5/monitor
 Requires: op5-naemon
 Requires: monitor-merlin
 Requires: monitor-livestatus
+Requires: op5-lmd
 
 %description monitoring
 Provides ORM, bindings and interfaces for Livestatus, Naemon and queryhandler.


### PR DESCRIPTION
As of Monitor 8, livestatus queries are made against LMD. To ensure all
integration tests works correct, we add LMD as a dependency to the
package.

Signed-off-by: Jacob Hansen <jhansen@op5.com>