### PR TITLE
Do not start LMD manually

### DIFF
--- a/op5build/monitor-ninja.spec
+++ b/op5build/monitor-ninja.spec
@@ -82,13 +82,6 @@ Requires: ruby-devel
 %description test
 Additional test files for ninja
 
-%post test
-%if 0%{?rhel} >= 7
-	systemctl start lmd
-%else
-	service lmd start
-%endif
-
 %package monitoring
 Summary: Naemon and Livestatus module for ninja
 Group: op5/monitor


### PR DESCRIPTION
As the issue with LMD not starting correctly, after LMD being installed,
should not be correct, we no longer need to start it manually here.

Signed-off-by: Jacob Hansen <jhansen@op5.com>