### PR TITLE
Adapt report header for logger reports

### DIFF
--- a/modules/reports/views/reports/header.php
+++ b/modules/reports/views/reports/header.php
@@ -17,15 +17,20 @@
 		<?php
 		// $report_time_formatted is already escaped
 		echo '<p>'._('Reporting period').': '.$report_time_formatted;
-		echo '<p>'._('Time zone').': '.$options['report_timezone'].' '.reports::timezone_utc_no($options['report_timezone']);
+		if ($type != 'logger') {
+			echo '<p>'._('Time zone').': '.$options['report_timezone'].' '.reports::timezone_utc_no($options['report_timezone']);
+		}
 		echo (isset($str_start_date) && isset($str_end_date)) ? ' ('.html::specialchars($str_start_date).' '._('to').' '.html::specialchars($str_end_date).')' : '';
 		echo '</p>';
 		if ($type == 'avail' || $type == 'sla') {
 			echo '<p>'.sprintf(_('Counting scheduled downtime as %s'), html::specialchars($options->get_value('scheduleddowntimeasuptime'))).'</p>';
 		}
-		if ($options['assumestatesduringnotrunning'])
+		if ($options['assumestatesduringnotrunning']) {
 			echo '<p>'.sprintf(_('Assuming previous state during program downtime')).'</p>';
-		echo '<p>'.sprintf(_('Showing %s'), html::specialchars($options->get_value('state_types')));
+		}
+		if ($type != 'logger') {
+			echo '<p>'.sprintf(_('Showing %s'), html::specialchars($options->get_value('state_types')));
+		}
 		$states = array();
 		if ($options['host_filter_status']) {
 			foreach ($options->get_alternatives('host_filter_status') as $state => $name) {


### PR DESCRIPTION
Stop try to print time zone and state types for logger reports.

When doing a "log archive search" from the Logger listview, a report of
type "logger" is created, which shares report header code with other
report types. But for a logger report, some data, like the
`report_timezone` added in MON-11209 is not available which causes a
call to `timezone_utc_no()` to crash.

This fixes MON-11763.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>