### PR TITLE
Use DEL_DOWNTIME_BY_HOST_NAME to delete downtimes

### DIFF
--- a/modules/monitoring/models/downtime.php
+++ b/modules/monitoring/models/downtime.php
@@ -16,10 +16,7 @@ class Downtime_Model extends BaseDowntime_Model {
 	 * @ninja orm_command view monitoring/naemon_command
 	 */
 	public function delete() {
-		$cmd = "DEL_HOST_DOWNTIME";
-		if($this->get_is_service()) {
-			$cmd = "DEL_SVC_DOWNTIME";
-		}
+		$cmd = "DEL_DOWNTIME_BY_HOST_NAME";
 		return $this->submit_naemon_command($cmd);
 	}
 

--- a/modules/monitoring/models/naemonobject.php
+++ b/modules/monitoring/models/naemonobject.php
@@ -16,9 +16,21 @@ class NaemonObject_Model extends Object_Model {
 		$cmd = array_shift($args);
 
 		if($this instanceof Downtime_Model || $this instanceof Comment_Model) {
-			// the downtime|comment models have "id;is_service" as
-			// keys, which does not correspond to the Neamon cmd
-			$key = $this->get_id();
+			if ($cmd === "DEL_DOWNTIME_BY_HOST_NAME") {
+				$service_desc = "";
+				if ($this->get_is_service()) {
+					$service_desc = $this->get_service()->get_description();
+				}
+				$key = sprintf("%s;%s;%s;%s",
+					$this->get_host()->get_name(),
+					$service_desc,
+					$this->get_start_time(),
+					$this->get_comment());
+			} else {
+				// the downtime|comment models have "id;is_service" as
+				// keys, which does not correspond to the Neamon cmd
+				$key = $this->get_id();
+			}
 		} else {
 			$key = $this->get_key();
 		}


### PR DESCRIPTION
To delete a downtime ninja would prior to this commit use the external
command DEL_HOST_DOWNTIME or DEL_SVC_DOWNTIME. However this would fail
to remove downtimes for peers and pollers iff the downtime was not yet
started.

This happens for two reasons:
1) Merlin cannot safely propagate DEL_HOST/SVC_DOWNTIME to other nodes
as this external command requires a downtime_id argument which is not
guaranteed to be the same on all nodes.

2) Instead Merlin relies on deleting downtimes when a
NEBATTR_DOWNTIME_STOP_CANCELLED event happens, which is propagated
across to all relevant nodes. However this event only occurs if a
downtime is deleted AFTER the downtime start time, and as a result it
would therefore be missed.

Instead we will use DEL_DOWNTIME_BY_HOST_NAME which we can safely
propagate to all relevant nodes, and it will correctly delete the
downtime. Furthermore this makes downtime deletion behaviour more
cosistent in case there are several downtimes for the same object, with
the same starttime and comment.

This fixes: MON-9109.

Dependent on: https://github.com/ITRS-Group/monitor-merlin/pull/43 to ensure we don't propagate this event to irrelevant nodes.