### PR TITLE
Change login button's size and text

### DIFF
--- a/application/views/css/form.css
+++ b/application/views/css/form.css
@@ -84,6 +84,8 @@ form.renderable legend {
 
 form.renderable-login input[type=submit]{
 	margin-top: 10px;
+	width: 83px;
+	height: 30px;
 }
 
 form.renderable input[type=submit],

--- a/features/password.feature
+++ b/features/password.feature
@@ -16,7 +16,7 @@ Feature: Change password
 		Then I should see "Username"
 		When I enter "administrator" into "username"
 		And I enter "billabong" into "password"
-		And I click "Login"
+		And I click "Log in"
 		And I hover the profile
 		And I click "My Account"
 		And I click "Change Password"

--- a/features/step_definitions/mocked_configuration.rb
+++ b/features/step_definitions/mocked_configuration.rb
@@ -76,7 +76,7 @@ When /^I am logged in as administrator$/ do
     When I am on the main page
     And I enter "#{username}" into "username"
     And I enter "#{password}" into "password"
-    And I click "Login"
+    And I click "Log in"
   }
 
   @mock.mock_class("op5MayI", {
@@ -174,7 +174,7 @@ When /^I am logged in as "(.*)"$/ do |user|
 		When I am on the main page
 		And I enter "#{username}" into "username"
 		And I enter "#{password}" into "password"
-		And I click "Login"
+		And I click "Log in"
 	}
 
 	@mock.mock_class("op5MayI", {

--- a/modules/auth/views/login.php
+++ b/modules/auth/views/login.php
@@ -46,7 +46,7 @@
 
 
 	<fieldset type="buttons">
-		<input type="submit" value="Login">
+		<input type="submit" value="Log in">
 	</fieldset>
 
 	<p class="rights">&#169;2019 ITRS GROUP LTD, ALL RIGHTS RESERVED</p>


### PR DESCRIPTION
The size of the login button is too small. Also, the text is not well
written.

If applied, this commit will change the size and the text.

This fixes MONUI-80

Signed-off-by: Adrián Villalba <avillalba@itrsgroup.com>