### PR TITLE
Enable gzip compression

### DIFF
--- a/op5build/ninja.httpd-conf
+++ b/op5build/ninja.httpd-conf
@@ -54,3 +54,30 @@ KeepAlive On
 	Order allow,deny
 	Deny from all
 </Location>
+
+# Enabled compression for HTML, CSS, JS, TEXT, XML, fonts
+# mod_deflate is enabled by default but in case it has been disabled
+# we put the compression in a conditional
+<IfModule mod_deflate.c>
+        AddOutputFilterByType DEFLATE application/javascript
+        AddOutputFilterByType DEFLATE application/rss+xml
+        AddOutputFilterByType DEFLATE application/vnd.ms-fontobject
+        AddOutputFilterByType DEFLATE application/x-font
+        AddOutputFilterByType DEFLATE application/x-font-opentype
+        AddOutputFilterByType DEFLATE application/x-font-otf
+        AddOutputFilterByType DEFLATE application/x-font-truetype
+        AddOutputFilterByType DEFLATE application/x-font-ttf
+        AddOutputFilterByType DEFLATE application/x-javascript
+        AddOutputFilterByType DEFLATE application/xhtml+xml
+        AddOutputFilterByType DEFLATE application/xml
+        AddOutputFilterByType DEFLATE font/opentype
+        AddOutputFilterByType DEFLATE font/otf
+        AddOutputFilterByType DEFLATE font/ttf
+        AddOutputFilterByType DEFLATE image/svg+xml
+        AddOutputFilterByType DEFLATE image/x-icon
+        AddOutputFilterByType DEFLATE text/css
+        AddOutputFilterByType DEFLATE text/html
+        AddOutputFilterByType DEFLATE text/javascript
+        AddOutputFilterByType DEFLATE text/plain
+        AddOutputFilterByType DEFLATE text/xml
+</IfModule>

--- a/op5build/ninja.httpd-conf.el7
+++ b/op5build/ninja.httpd-conf.el7
@@ -51,3 +51,30 @@ KeepAlive On
 	Order allow,deny
 	Deny from all
 </Location>
+
+# Enabled compression for HTML, CSS, JS, TEXT, XML, fonts
+# mod_deflate is enabled by default but in case it has been disabled
+# we put the compression in a conditional
+<IfModule mod_deflate.c>
+        AddOutputFilterByType DEFLATE application/javascript
+        AddOutputFilterByType DEFLATE application/rss+xml
+        AddOutputFilterByType DEFLATE application/vnd.ms-fontobject
+        AddOutputFilterByType DEFLATE application/x-font
+        AddOutputFilterByType DEFLATE application/x-font-opentype
+        AddOutputFilterByType DEFLATE application/x-font-otf
+        AddOutputFilterByType DEFLATE application/x-font-truetype
+        AddOutputFilterByType DEFLATE application/x-font-ttf
+        AddOutputFilterByType DEFLATE application/x-javascript
+        AddOutputFilterByType DEFLATE application/xhtml+xml
+        AddOutputFilterByType DEFLATE application/xml
+        AddOutputFilterByType DEFLATE font/opentype
+        AddOutputFilterByType DEFLATE font/otf
+        AddOutputFilterByType DEFLATE font/ttf
+        AddOutputFilterByType DEFLATE image/svg+xml
+        AddOutputFilterByType DEFLATE image/x-icon
+        AddOutputFilterByType DEFLATE text/css
+        AddOutputFilterByType DEFLATE text/html
+        AddOutputFilterByType DEFLATE text/javascript
+        AddOutputFilterByType DEFLATE text/plain
+        AddOutputFilterByType DEFLATE text/xml
+</IfModule>


### PR DESCRIPTION
This commit enables gzip compression in the apache http web server.
According to the chrome developer audit tool, this change brings the
performance score for monitor in the browser from 1 to 32 points out of
a 100.

Fixes: MON-10630

Signed-off-by: Erik Sjöström <esjostrom@op5.com>