### PR TITLE
Add message info when LMD or Livestatus are down

### DIFF
--- a/application/views/css/layout.css
+++ b/application/views/css/layout.css
@@ -1212,6 +1212,11 @@ h1.emote b {
   border-bottom: 2px solid #ef3b4f;
 }
 
+.info-notice-service-error {
+  margin-top: 20px;
+  margin-left: 10px;
+}
+
 .notify-notification-bar .notify-notification.pending,
 .alert.pending,
 .state-background.pending {

--- a/application/views/template.php
+++ b/application/views/template.php
@@ -45,12 +45,21 @@
 								echo $content;
 							}
 						} else {
-							echo 'Page does not have any content';
+							$services_down = 'services LMD and Naemon are not running';
+
+							// Check LMD.
+							exec('service lmd status', $output, $return_var_lmd);
+							// Check Livestatus.
+							exec('service naemon status', $output, $return_var_le);
+
+							if($return_var_lmd !== 0 && $return_var_le === 0){
+								$services_down = 'service LMD is not running';
+							}
+							echo '<div class=" info-notice info-notice-error info-notice-service-error">';
+								echo 'The OP5 Monitor '.$services_down.', please contact your administrator.';
+							echo '</div>';
 						}
-
-
 					?>
-
 				</div>
 
 			<?php


### PR DESCRIPTION
If LMD or Livestatus are down only a message saying "Page has no content"
is shown. This is not too much information for the user.

If this commit is applied, the user will know which service is not running.

This fixes MONUI-76

Signed-off-by: Adrián Villalba <avillalba@itrsgroup.com>