### PR TITLE
Update links to OP5 Monitor page

### DIFF
--- a/application/config/menu.php
+++ b/application/config/menu.php
@@ -1,4 +1,4 @@
 <?php defined('SYSPATH') OR die('No direct access allowed.');
 
 $config['items'] = false;
-$config['manual_url'] = 'https://docs.itrsgroup.com/';
+$config['manual_url'] = 'https://docs.itrsgroup.com/docs/op5-monitor/';

--- a/features/menu.feature
+++ b/features/menu.feature
@@ -68,7 +68,7 @@ Feature: Menu
 	@unreliable_el7 @unreliable
 	Scenario: Verify that the Manual link goes to the KB
 		When I hover the branding
-		Then I should see css "a[href='https://docs.itrsgroup.com/']"
+		Then I should see css "a[href='https://docs.itrsgroup.com/docs/op5-monitor/']"
 
 	Scenario: Validate quicklink absolute URL
 		When I click "Manage quickbar"

--- a/modules/menu/views/about.php
+++ b/modules/menu/views/about.php
@@ -5,7 +5,7 @@
   <table class="popup-about-table">
     <tr class="popup-about-row popup-about-row-links">
       <td>
-        <a href="https://docs.itrsgroup.com">Knowledge Base</a>
+        <a href="https://docs.itrsgroup.com/docs/op5-monitor/">Knowledge Base</a>
       </td>
       <td>
         <a href="http://www.op5.com">www.op5.com</a>

--- a/test/backup_Test.php
+++ b/test/backup_Test.php
@@ -2,7 +2,7 @@
 /**
  * Test the backup functions that are reached through the GUI. There are other
  * types of backups being run too, you can read more about backups here:
- * https://docs.itrsgroup.com/
+ * https://docs.itrsgroup.com/docs/op5-monitor/
  * Search for "backup" under OP5 monitor
  */
 class Backup_Test extends PHPUnit_Framework_TestCase {


### PR DESCRIPTION
The links to our documentation linked to the general support page for
ITRS. This will now link to OP5 Monitors page in the support portal

Signed-off-by: Axel Bolle <abolle@itrsgroup.com>