### PR TITLE
Fix manage in menu margin top

### DIFF
--- a/modules/menu/hooks/menu_main_hook.php
+++ b/modules/menu/hooks/menu_main_hook.php
@@ -13,6 +13,8 @@ Event::insert_event('ninja.menu.setup', 0, function () {
 
     $menu->set('Report', null, 3, '', array('style' => 'margin-top: 8px'));
 
+    $menu->set('Manage', null, 4, '', array('style' => 'margin-top: 8px'));
+
     Event::$data = $menu;
 
 });


### PR DESCRIPTION
If LMD is not running, manage in menu has an incorrect margin top.
With this commit, the margin top will be the correct.

This fixes MONUI-107

Signed-off-by: Adrián Villalba <avillalba@itrsgroup.com>