### PR TITLE
Change tooltip text in extinfo page

### DIFF
--- a/application/controllers/search.php
+++ b/application/controllers/search.php
@@ -304,7 +304,7 @@ class Search_Controller extends Ninja_Controller {
 		),
 		'saved_search_help' => _('Click to save this search for later use. Your saved searches will be available by clicking on the icon just below the search field at the top of the page.'),
 		'filterbox' => _('When you start to type, the visible content gets filtered immediately.<br /><br />If you press <kbd>enter</kbd> or the button "Search through all result pages", you filter all result pages but <strong>only through its primary column</strong> (<em>host name</em> for host objects, etc).'),
-		'runtime_options' => _('<div class="runtime-options-tooltip-text"><p>The settings are reset at restart.</p> <p>To make persistent changes, go<p/> to the configuration page.</div>')
+		'runtime_options' => _('<div class="runtime-options-tooltip-text"><p>The settings can be overwritten by configuration changes.</p><p>To make persistent changes, go to the configuration page.</p></div>')
 
 		);
 		if (array_key_exists($id, $helptexts)) {


### PR DESCRIPTION
The tooltip for runtime options in the extinfo page is not correct since
the settings stay after restart.

If applied, this commit will change the text.

This fixes MONUI-132

Signed-off-by: Adrián Villalba <avillalba@itrsgroup.com>