### PR TITLE
Fix report schedules for reports with missing timezone

### DIFF
--- a/modules/reports/controllers/schedule.php
+++ b/modules/reports/controllers/schedule.php
@@ -164,6 +164,10 @@ class Schedule_Controller extends Authenticated_Controller
 		$type = Scheduled_reports_Model::get_typeof_report($schedule_id);
 		$opt_obj = Scheduled_reports_Model::get_scheduled_data($schedule_id);
 		$report = Report_options::setup_options_obj($type, $opt_obj);
+
+		$this->log->log('notice', "Sending report id={$opt_obj['report_id']}, " .
+			"filename={$opt_obj['filename']}, schedule_id=$schedule_id");
+
 		if (!$report) {
 			$msg = sprintf(_("Failed to load %s report from schedule %s"), $type, $schedule_id);
 			if (request::is_ajax()) {

--- a/modules/reports/models/scheduled_reports.php
+++ b/modules/reports/models/scheduled_reports.php
@@ -337,6 +337,7 @@ class Scheduled_reports_Model extends Model
 	{
 		$schedules = array();
 		$send_date = array();
+		$default_timezone = date_default_timezone_get();
 
 		$db = Database::instance();
 
@@ -352,10 +353,9 @@ SQL;
 		foreach($res as $row){
 			$report_period = json_decode($row->report_period);
 			$report_time = $row->report_time;
-			$report_timezone = $row->timezone;
-			if($report_timezone != ''){
+			if($row->timezone){
 				// All times for this schedule use the timezone of the associated report.
-				date_default_timezone_set( $report_timezone );
+				date_default_timezone_set($row->timezone);
 			}
 
 			$repeat_no = $report_period->no;
@@ -475,6 +475,7 @@ SQL;
 					$send_date[] = $now->format('Y-m-d');
 				}
 			}
+			date_default_timezone_set($default_timezone);
 		}
 
 		foreach($schedules as $i => $schedule_id ){

--- a/modules/reports/models/scheduled_reports.php
+++ b/modules/reports/models/scheduled_reports.php
@@ -344,7 +344,7 @@ class Scheduled_reports_Model extends Model
 		SELECT sr.*, rp.periodname, opt.value AS timezone
 		FROM scheduled_reports sr
 		INNER JOIN scheduled_report_periods rp ON rp.id = sr.period_id
-		INNER JOIN saved_reports_options opt ON opt.report_id = sr.report_id
+		LEFT JOIN saved_reports_options opt ON opt.report_id = sr.report_id
 			AND opt.name = 'report_timezone'
 SQL;
 		$res = $db->query($sql);


### PR DESCRIPTION
With this patch we will not assume that there is a 'report_timezone'
report option stored, which is the case for reports that were saved
before the 'report_timezone' option was introduced.

Log to Ninja log on notice level (not enabled by default) when sending
reports, so that it can be tracked easier whether we're trying to send
reports when scheduled or not.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>

This fixes MON-11912.