### PR TITLE
Clarify description text for commands

### DIFF
--- a/modules/monitoring/models/host.php
+++ b/modules/monitoring/models/host.php
@@ -828,7 +828,7 @@ class Host_Model extends BaseHost_Model {
 	 * @ninja orm_command params.forced.name Forced
 	 * @ninja orm_command params.forced.default 1
 	 * @ninja orm_command params.forced.description
-	 * 		Naemon should force a check of the services, regardless of scheduled check time and whether checks disabled.
+	 * 		Naemon should force a check of the services, regardless of scheduled check time and whether checks are disabled.
      *
 	 * @ninja orm_command description
 	 *     This command is used to scheduled the next check of all services on

--- a/modules/monitoring/models/host.php
+++ b/modules/monitoring/models/host.php
@@ -829,7 +829,7 @@ class Host_Model extends BaseHost_Model {
 	 * @ninja orm_command params.forced.default 1
 	 * @ninja orm_command params.forced.description
 	 * 		Naemon should force a check of the services, regardless of scheduled check time and whether checks are disabled.
-     *
+	 *
 	 * @ninja orm_command description
 	 *     This command is used to scheduled the next check of all services on
 	 *     the specified host. If you select the <i>force check</i> option,

--- a/modules/monitoring/models/host.php
+++ b/modules/monitoring/models/host.php
@@ -248,21 +248,21 @@ class Host_Model extends BaseHost_Model {
 	 * @ninja orm_command params.sticky.name Sticky
 	 * @ninja orm_command params.sticky.default 1
 	 * @ninja orm_command params.sticky.description
-	 * 		If you want acknowledgement to disable notifications until the host recovers, check this checkbox.
+	 * 		Acknowledgement should disable notifications until the host recovers.
 	 *
 	 * @ninja orm_command params.notify.id 2
 	 * @ninja orm_command params.notify.type bool
 	 * @ninja orm_command params.notify.name Notify
 	 * @ninja orm_command params.notify.default 1
 	 * @ninja orm_command params.notify.description
-	 * 		If you want an acknowledgement notification sent out to the appropriate contacts, check this checkbox.
+	 * 		Send acknowledgement notification to the appropriate contacts. Downtime will not block this notification.
 	 *
 	 * @ninja orm_command params.persistent.id 3
 	 * @ninja orm_command params.persistent.type bool
 	 * @ninja orm_command params.persistent.name Persistent
 	 * @ninja orm_command params.persistent.default 1
 	 * @ninja orm_command params.persistent.description
-	 * 		If you would like the host comment to remain once the acknowledgement is removed, check this checkbox.
+	 * 		Host comment should remain after acknowledgement is removed.
 	 *
 	 * @ninja orm_command mayi_method update.command.acknowledge
 	 * @ninja orm_command description
@@ -443,7 +443,7 @@ class Host_Model extends BaseHost_Model {
 	 * @ninja orm_command params.forced.name Force check
 	 * @ninja orm_command params.forced.default 1
 	 * @ninja orm_command params.forced.description
-	 * 		If you want Naemon to force a check of the host regardless of both what time the scheduled check occurs and whether or not checks are enabled for the host, check this checkbox.
+	 * 		Naemon should force a check of the host, regardless of scheduled check time and whether checks are disabled for this host.
 	 *
 	 * @ninja orm_command description
 	 *     This command is used to schedule the next check of a host. Naemon
@@ -828,8 +828,8 @@ class Host_Model extends BaseHost_Model {
 	 * @ninja orm_command params.forced.name Forced
 	 * @ninja orm_command params.forced.default 1
 	 * @ninja orm_command params.forced.description
-	 * 		If you want Naemon to force a check of the services regardless of both what time the scheduled check occurs and whether or not checks are enabled for the services, check this checkbox.
-	 *
+	 * 		Naemon should force a check of the services, regardless of scheduled check time and whether checks disabled.
+     *
 	 * @ninja orm_command description
 	 *     This command is used to scheduled the next check of all services on
 	 *     the specified host. If you select the <i>force check</i> option,

--- a/modules/monitoring/models/service.php
+++ b/modules/monitoring/models/service.php
@@ -474,7 +474,7 @@ class Service_Model extends BaseService_Model {
 	 * @ninja orm_command params.forced.default 1
 	 * @ninja orm_command params.forced.description
 	 * 		Naemon should force a check of the service, regardless of scheduled check time, and whether checks are disabled for this service.
-     *
+	 *
 	 * @ninja orm_command description
 	 *     This command is used to schedule the next check of a service. Naemon
 	 *     will re-queue the service to be checked at the time you specify. If

--- a/modules/monitoring/models/service.php
+++ b/modules/monitoring/models/service.php
@@ -260,21 +260,21 @@ class Service_Model extends BaseService_Model {
 	 * @ninja orm_command params.sticky.name Sticky
 	 * @ninja orm_command params.sticky.default 1
 	 * @ninja orm_command params.sticky.description
-	 * 		If you want acknowledgement to disable notifications until the service recovers, check this checkbox.
+	 * 		Acknowledgement should disable notifications until the service recovers.
 	 *
 	 * @ninja orm_command params.notify.id 2
 	 * @ninja orm_command params.notify.type bool
 	 * @ninja orm_command params.notify.name Notify
 	 * @ninja orm_command params.notify.default 1
 	 * @ninja orm_command params.notify.description
-	 * 		If you want an acknowledgement notification sent out to the appropriate contacts, check this checkbox.
+	 * 		Send acknowledgement notification to the appropriate contacts. Downtime will not block this notification.
 	 *
 	 * @ninja orm_command params.persistent.id 3
 	 * @ninja orm_command params.persistent.type bool
 	 * @ninja orm_command params.persistent.name Persistent
 	 * @ninja orm_command params.persistent.default 1
 	 * @ninja orm_command params.persistent.description
-	 * 		If you would like the service comment to remain once the acknowledgement is removed, check this checkbox.
+	 * 		Service comment should remain after the acknowledgement is removed.
 	 *
 	 * @ninja orm_command mayi_method update.command.acknowledge
 	 * @ninja orm_command description
@@ -473,8 +473,8 @@ class Service_Model extends BaseService_Model {
 	 * @ninja orm_command params.forced.name Force check
 	 * @ninja orm_command params.forced.default 1
 	 * @ninja orm_command params.forced.description
-	 * 		If you want Naemon to force a check of the service regardless of both what time the scheduled check occurs and whether or not checks are enabled for the service, check this checkbox.
-	 *
+	 * 		Naemon should force a check of the service, regardless of scheduled check time, and whether checks are disabled for this service.
+     *
 	 * @ninja orm_command description
 	 *     This command is used to schedule the next check of a service. Naemon
 	 *     will re-queue the service to be checked at the time you specify. If


### PR DESCRIPTION
These descriptions are visible when acknowledging the state of
an object in the UI, through the extinfo page or via the drop-down.

1) When using a checkbox in a UI, it's implicit that leaving that
box checked is a "yes" answer to the text provided, so there is no
need to say "If you want ... check this checkbox". This change
makes the descriptions shorter and hopefully more clear.

2) On customer request, we have added a note that if the object is
in a scheduled downtime, the acknowledgement notification will be
sent regardless. This is maybe not intuitive or obvious, but it's
the way it is so the text should probably underline this fact.

This fixes MONUI-155