### PR TITLE
Bugfix/mon 11953 disallow command chaining in test check

### DIFF
--- a/etc/auth.yml
+++ b/etc/auth.yml
@@ -5,6 +5,6 @@ common:
   apc_enabled: false
   apc_ttl: 60
   apc_store_prefix: "op5_login_"
-  version: 8
+  version: 9
 Default:
   driver: "Default"

--- a/etc/auth_groups.yml
+++ b/etc/auth_groups.yml
@@ -2,6 +2,7 @@
 admins:
   - "FILE"
   - "access_rights"
+  - "allow_dangerous_characters"
   - "api_command"
   - "api_config"
   - "api_perfdata"

--- a/install_scripts/migrate_auth.php
+++ b/install_scripts/migrate_auth.php
@@ -84,6 +84,9 @@ $new_rights = array(
 			'traps_view_all',
 		)
 	),
+	8 => array(
+		$considered_superadmin => 'allow_dangerous_characters',
+	),
 );
 
 

--- a/src/op5/auth/Authorization.php
+++ b/src/op5/auth/Authorization.php
@@ -158,7 +158,8 @@ class op5Authorization {
 			'trapper' => array('traps_view_all' => ''),
 			'misc' => array ('FILE' => '','access_rights' => '','pnp' => '',
 				'manage_trapper' => '',
-				'saved_filters_global' => ''));
+				'saved_filters_global' => '',
+				'allow_dangerous_characters' => ''));
 	}
 
 	/**


### PR DESCRIPTION
This will add the option "allow_dangerous_characters" to the grouprights view in monitor.

I decided to use the Allow - opt in, option because all "superadmins" needs to have access to all available config settings. For all other users this is off by default.