### PR TITLE
Fix deletion of all downtimes (7.5)

### DIFF
--- a/modules/monitoring/models/host.php
+++ b/modules/monitoring/models/host.php
@@ -633,16 +633,7 @@ class Host_Model extends BaseHost_Model {
 	 * @return array ['status' => boolean, 'output' => string]
 	 */
 	public function cancel_all_downtimes() {
-		$downtime_set = ObjectPool_Model::get_by_query('[downtimes] host.name = "'.$this->get_name().'"');
-		foreach($downtime_set->it(array(),array(), false, 0) as $downtime) {
-			$output = $downtime->delete();
-			if (!$output['status'])
-				return $output;
-		}
-		return array(
-			'status' => True,
-			'output' => sprintf(_('Your command was successfully submitted to %s.'), Kohana::config('config.product_name'))
-		);
+		return $this->del_downtime_by_host_name($this->get_name());
 	}
 
 	/**

--- a/modules/monitoring/models/service.php
+++ b/modules/monitoring/models/service.php
@@ -640,16 +640,7 @@ class Service_Model extends BaseService_Model {
 	 * @return array ['status' => boolean, 'output' => string]
 	 */
 	public function cancel_all_downtimes() {
-		$downtime_set = ObjectPool_Model::get_by_query('[downtimes] service.display_name = "'.$this->get_description().'" and host.name = "'.$this->get_host()->get_name().'"');
-		foreach($downtime_set->it(array(),array(), false, 0) as $downtime) {
-			$output = $downtime->delete();
-			if (!$output['status'])
-				return $output;
-		}
-		return array(
-			'status' => True,
-			'output' => sprintf(_('Your command was successfully submitted to %s.'), Kohana::config('config.product_name'))
-		);
+		return $this->del_downtime_by_host_name($this->get_host()->get_name(), $this->get_description());
 	}
 
 	/**


### PR DESCRIPTION
Previously, all downtimes were deleted by using the
DEL_HOST/SVC_DOWNTIME external command. However this was changed in
937db15e27c413da00d7564744a386227307b556 to use `DEL_DOWNTIME_BY_HOSTNAME`
instead.

This, seemed to have caused a regression for deleting all downtimes of a
host/service.

This commit the downtimes can be deleted correctly when calling the
cancel all function.

Fixes: MON-12040

Signed-off-by: Jacob Hansen <jhansen@op5.com>