### PR TITLE
Disable apache gzip compression for EL6 (maint/7.5)

### DIFF
--- a/op5build/ninja.httpd-conf
+++ b/op5build/ninja.httpd-conf
@@ -54,30 +54,3 @@ KeepAlive On
 	Order allow,deny
 	Deny from all
 </Location>
-
-# Enabled compression for HTML, CSS, JS, TEXT, XML, fonts
-# mod_deflate is enabled by default but in case it has been disabled
-# we put the compression in a conditional
-<IfModule mod_deflate.c>
-        AddOutputFilterByType DEFLATE application/javascript
-        AddOutputFilterByType DEFLATE application/rss+xml
-        AddOutputFilterByType DEFLATE application/vnd.ms-fontobject
-        AddOutputFilterByType DEFLATE application/x-font
-        AddOutputFilterByType DEFLATE application/x-font-opentype
-        AddOutputFilterByType DEFLATE application/x-font-otf
-        AddOutputFilterByType DEFLATE application/x-font-truetype
-        AddOutputFilterByType DEFLATE application/x-font-ttf
-        AddOutputFilterByType DEFLATE application/x-javascript
-        AddOutputFilterByType DEFLATE application/xhtml+xml
-        AddOutputFilterByType DEFLATE application/xml
-        AddOutputFilterByType DEFLATE font/opentype
-        AddOutputFilterByType DEFLATE font/otf
-        AddOutputFilterByType DEFLATE font/ttf
-        AddOutputFilterByType DEFLATE image/svg+xml
-        AddOutputFilterByType DEFLATE image/x-icon
-        AddOutputFilterByType DEFLATE text/css
-        AddOutputFilterByType DEFLATE text/html
-        AddOutputFilterByType DEFLATE text/javascript
-        AddOutputFilterByType DEFLATE text/plain
-        AddOutputFilterByType DEFLATE text/xml
-</IfModule>


### PR DESCRIPTION
Partly revert of 94721c0b1adba56faf0dd9502e034ba3863f9231

Fixes MON-12022.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>