### PR TITLE
Fix delete downtime by hostname action in GUI (7.5)

### DIFF
--- a/modules/monitoring/models/host.php
+++ b/modules/monitoring/models/host.php
@@ -1083,28 +1083,26 @@ class Host_Model extends BaseHost_Model {
 	 * @param downtime_start_time = ""
 	 * @param comment = true
 	 *
-	 * @ninja orm_command name Delete downtime
+	 * @ninja orm_command name Delete downtime by hostname
 	 * @ninja orm_command category Actions
 	 * @ninja orm_command icon scheduled-downtime
 	 *
 	 * @ninja orm_command params.host_name.id 0
 	 * @ninja orm_command params.host_name.type string
-	 * @ninja orm_command params.host_name.name Host_name
+	 * @ninja orm_command params.host_name.name Host name
 	 *
 	 * @ninja orm_command params.service_description.id 1
 	 * @ninja orm_command params.service_description.type string
 	 * @ninja orm_command params.service_description.name Service description
-	 * @ninja orm_command params.service_description.default ""
 	 *
 	 * @ninja orm_command params.downtime_start_time.id 2
 	 * @ninja orm_command params.downtime_start_time.type time
 	 * @ninja orm_command params.downtime_start_time.name Downtime start time
-	 * @ninja orm_command params.downtime_start_time.default ""
+	 * @ninja orm_command params.downtime_start_time.default now
 	 *
 	 * @ninja orm_command params.comment.id 3
-	 * @ninja orm_command params.comment.type bool
+	 * @ninja orm_command params.comment.type string
 	 * @ninja orm_command params.comment.name Comment
-	 * @ninja orm_command params.comment.default ""
 	 *
 	 * @ninja orm_command mayi_method update.command.downtime
 	 * @ninja orm_command description
@@ -1115,7 +1113,19 @@ class Host_Model extends BaseHost_Model {
 	 * @ninja orm_command view monitoring/naemon_command
 	 */
 	public function del_downtime_by_host_name($host_name, $service_description="", $downtime_start_time="", $comment="") {
-		return $this->submit_naemon_command("DEL_DOWNTIME_BY_HOST_NAME", $host_name, $service_description, $downtime_start_time, $comment);
+		if (empty($downtime_start_time)) {
+			$start_tstamp = "";
+		} else {
+			$start_tstamp = date::timestamp_format(false, $downtime_start_time);
+			if($start_tstamp === false) {
+				return array(
+					'status' => false,
+					'output' => $downtime_start_time . " is not a valid date, please adjust it"
+				);
+			}
+		}
+
+		return $this->submit_naemon_command("DEL_DOWNTIME_BY_HOST_NAME", $host_name, $service_description, $start_tstamp, $comment);
 	}
 
 }

--- a/modules/monitoring/models/service.php
+++ b/modules/monitoring/models/service.php
@@ -965,7 +965,7 @@ class Service_Model extends BaseService_Model {
 	 * @param downtime_start_time = ""
 	 * @param comment = true
 	 *
-	 * @ninja orm_command name Delete downtime
+	 * @ninja orm_command name Delete downtime by hostname
 	 * @ninja orm_command category Actions
 	 * @ninja orm_command icon scheduled-downtime
 	 *
@@ -980,12 +980,11 @@ class Service_Model extends BaseService_Model {
 	 * @ninja orm_command params.downtime_start_time.id 2
 	 * @ninja orm_command params.downtime_start_time.type time
 	 * @ninja orm_command params.downtime_start_time.name Downtime start time
-	 * @ninja orm_command params.downtime_start_time.default ""
+	 * @ninja orm_command params.downtime_start_time.default now
 	 *
 	 * @ninja orm_command params.comment.id 3
-	 * @ninja orm_command params.comment.type bool
+	 * @ninja orm_command params.comment.type string
 	 * @ninja orm_command params.comment.name Comment
-	 * @ninja orm_command params.comment.default ""
 	 *
 	 * @ninja orm_command mayi_method update.command.downtime
 	 * @ninja orm_command description
@@ -996,6 +995,18 @@ class Service_Model extends BaseService_Model {
 	 * @ninja orm_command view monitoring/naemon_command
 	 */
 	public function del_downtime_by_host_name($host_name, $service_description, $downtime_start_time="", $comment="") {
-		return $this->submit_naemon_command("DEL_DOWNTIME_BY_HOST_NAME", $host_name, $service_description, $downtime_start_time, $comment);
+		if (empty($downtime_start_time)) {
+			$start_tstamp = "";
+		} else {
+			$start_tstamp = date::timestamp_format(false, $downtime_start_time);
+			if($start_tstamp === false) {
+				return array(
+					'status' => false,
+					'output' => $downtime_start_time . " is not a valid date, please adjust it"
+				);
+			}
+		}
+
+		return $this->submit_naemon_command("DEL_DOWNTIME_BY_HOST_NAME", $host_name, $service_description, $start_tstamp, $comment);
 	}
 }


### PR DESCRIPTION
Following adding the option to delete downtimes via the API, an unwanted
side effect occured, where we got a new "Delete Downtime" option in
listviews. This did not work, causing confusing.

It appears as though it is not possible to hide this action from the
listviews, without affecting the API. This commit therefore fixes the
view so that the command can be sent successfully via the GUI.

This fixes: MON-12088

Signed-off-by: Jacob Hansen <jhansen@op5.com>