### PR TITLE
Bugfix/mon 12113 mon 11953 may break nrpe checks

### DIFF
--- a/etc/auth.yml
+++ b/etc/auth.yml
@@ -5,6 +5,6 @@ common:
   apc_enabled: false
   apc_ttl: 60
   apc_store_prefix: "op5_login_"
-  version: 9
+  version: 10
 Default:
   driver: "Default"

--- a/etc/auth_groups.yml
+++ b/etc/auth_groups.yml
@@ -2,7 +2,6 @@
 admins:
   - "FILE"
   - "access_rights"
-  - "allow_dangerous_characters"
   - "api_command"
   - "api_config"
   - "api_perfdata"

--- a/install_scripts/migrate_auth.php
+++ b/install_scripts/migrate_auth.php
@@ -84,7 +84,10 @@ $new_rights = array(
 			'traps_view_all',
 		)
 	),
-	8 => array(
+);
+
+$deprecated_rights = array(
+	10 => array(
 		$considered_superadmin => 'allow_dangerous_characters',
 	),
 );
@@ -104,6 +107,17 @@ if(isset($config['common']['version'])) {
 foreach ($groups as &$group) {
 	for ($i = $current_version; $i < count($new_rights); $i++) {
 		foreach ($new_rights[$i] as $from => $to) {
+			if (in_array($from, $group)) {
+				if (is_array($to)) {
+					foreach ($to as $perm) {
+						$group[] = $perm;
+					}
+				} else {
+					$group[] = $to;
+				}
+			}
+		}
+		foreach ($deprecated_rights[$i] as $from => $to) {
 			if (in_array($from, $group)) {
 				if (is_array($to)) {
 					foreach ($to as $perm) {

--- a/install_scripts/migrate_auth.php
+++ b/install_scripts/migrate_auth.php
@@ -117,17 +117,6 @@ foreach ($groups as &$group) {
 				}
 			}
 		}
-		foreach ($deprecated_rights[$i] as $from => $to) {
-			if (in_array($from, $group)) {
-				if (is_array($to)) {
-					foreach ($to as $perm) {
-						$group[] = $perm;
-					}
-				} else {
-					$group[] = $to;
-				}
-			}
-		}
 	}
 }
 $config['common']['version'] = $i;

--- a/src/op5/auth/Authorization.php
+++ b/src/op5/auth/Authorization.php
@@ -159,7 +159,7 @@ class op5Authorization {
 			'misc' => array ('FILE' => '','access_rights' => '','pnp' => '',
 				'manage_trapper' => '',
 				'saved_filters_global' => '',
-				'allow_dangerous_characters' => ''));
+				'disallow_dangerous_characters' => ''));
 	}
 
 	/**

--- a/test/auth_files_Test.php
+++ b/test/auth_files_Test.php
@@ -104,6 +104,9 @@ class AuthFilesTest extends PHPUnit_Framework_TestCase {
 			'pnp',
 			'saved_filters_global',
 		);
+		$this->non_positive_rights = array(
+			'disallow_dangerous_characters',
+		);
 	}
 
 	public function tearDown() {
@@ -190,11 +193,16 @@ class AuthFilesTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function test_admins_group_should_have_access_to_all_auth_rights_that_exist() {
 		$config = new op5config(array('basepath' => __DIR__."/../etc"));
-
+		$auth_rights = $this->get_all_auth_rights();	
+		foreach ($this->non_positive_rights as $rule){
+			if (($key = array_search($rule, $auth_rights)) !== false) {
+				 unset($auth_rights[$key]);
+			}			
+		}
 		$this->assertEquals(
 			array(),
 			array_diff(
-				$this->get_all_auth_rights(),
+				$auth_rights,
 				$config->getConfig("auth_groups.admins")
 			),
 			"Some auth rights are missing from the admins group ".
@@ -341,7 +349,7 @@ class AuthFilesTest extends PHPUnit_Framework_TestCase {
 			"Failed a safety check"
 		);
 
-		$all_rights = array_merge($this->preexisting_rights, $this->flatten_new_rights($new_rights));
+		$all_rights = array_merge($this->preexisting_rights, $this->flatten_new_rights($new_rights), $this->non_positive_rights);
 
 		$this->assertEquals(
 			array(),

--- a/test/auth_files_Test.php
+++ b/test/auth_files_Test.php
@@ -12,6 +12,7 @@ class AuthFilesTest extends PHPUnit_Framework_TestCase {
 	private $tmp_auth_groups_file;
 	private $tmp_auth_file;
 	private $preexisting_rights = array();
+	private $non_permissive_rights = array();
 
 	public function setUp() {
 		$this->tmp_auth_groups_file = __DIR__.'/auth_groups.yml';
@@ -104,7 +105,7 @@ class AuthFilesTest extends PHPUnit_Framework_TestCase {
 			'pnp',
 			'saved_filters_global',
 		);
-		$this->non_positive_rights = array(
+		$this->non_permissive_rights = array(
 			'disallow_dangerous_characters',
 		);
 	}
@@ -191,14 +192,22 @@ class AuthFilesTest extends PHPUnit_Framework_TestCase {
 	 * to pay for having this testable without any logic regarding which
 	 * auth right is a subset of another.
 	 */
-	public function test_admins_group_should_have_access_to_all_auth_rights_that_exist() {
+	public function test_admins_group_should_have_access_to_all_permissive_auth_rights_that_exist() {
 		$config = new op5config(array('basepath' => __DIR__."/../etc"));
-		$auth_rights = $this->get_all_auth_rights();	
-		foreach ($this->non_positive_rights as $rule){
-			if (($key = array_search($rule, $auth_rights)) !== false) {
+		$auth_rights = $this->get_all_auth_rights();
+
+		/**
+		 * We introduced a new group right that is non_permissive,
+		 * I.E it restricts the user rather than allows. This requires
+		 * removal of these rights in order to check if all positive rights are applied
+		 * since the admin user does not get this by default
+		 */
+		foreach ($this->non_permissive_rights as $right){
+			if (($key = array_search($right, $auth_rights)) !== false) {
 				 unset($auth_rights[$key]);
-			}			
+			}
 		}
+
 		$this->assertEquals(
 			array(),
 			array_diff(
@@ -349,7 +358,7 @@ class AuthFilesTest extends PHPUnit_Framework_TestCase {
 			"Failed a safety check"
 		);
 
-		$all_rights = array_merge($this->preexisting_rights, $this->flatten_new_rights($new_rights), $this->non_positive_rights);
+		$all_rights = array_merge($this->preexisting_rights, $this->flatten_new_rights($new_rights), $this->non_permissive_rights);
 
 		$this->assertEquals(
 			array(),


### PR DESCRIPTION
This will remove the old group right "allow_dangerous_chacters" and introduce a new group right: "disallow_dangerous_characters". 

This will make the group right setting opt-in rather than opt-out.