### PR TITLE
Fix double quicklins when indexes are out of order

### DIFF
--- a/application/models/ninja_setting.php
+++ b/application/models/ninja_setting.php
@@ -93,8 +93,16 @@ class Ninja_setting_Model extends Model {
 			if ($page === 'tac' && $type === 'dojo-quicklinks') {
 				$json_obj = $obj['setting'];
 				$decoded_array = json_decode($obj['setting']);
-				$unique = json_encode(array_unique($decoded_array, SORT_REGULAR));
-				$obj['setting'] = $unique;
+				$unique = array_unique($decoded_array, SORT_REGULAR);
+				/* We need to iterate over the array here, as
+				 * array_unique might return arrays with { [0] => ... [2] => ...
+				 * As the above would result in json_encode to encode the json
+				 * objects with indexes, which breaks things later on */
+				$unique_ordered_keys = array();
+				foreach ($unique as &$quicklink) {
+					array_push($unique_ordered_keys, $quicklink);
+				}
+				$obj['setting'] = json_encode($unique_ordered_keys);
 			}
 			return (object) $obj;
 		}


### PR DESCRIPTION
In the previous commit: 925b87b duplicate quicklinks was fixed.

However in some cases the fix would not work. The reason for this was
that array_unique would leave index gaps in an indexed. That is you
could end up with an array like:

```
[0] => ...
[2] => ...
```

When then encoding the array with `json_encode`, the we would get an
indexed array like so:
`{"0":{quicklink}, "2":{quicklink}`
instead of the desired format:
`[{quicklink},{quicklink}]`

Signed-off-by: Jacob Hansen <jhansen@op5.com>