### PR TITLE
Add first day of month schedule option (maint/7.5)

### DIFF
--- a/features/schedule.feature
+++ b/features/schedule.feature
@@ -157,7 +157,7 @@ Feature: Scheduled reports
 		Then I should see "Report was successfully saved"
 
 	@reports
-	Scenario: Schedule SLA report
+	Scenario: Schedule SLA report on first day of every second month
 		Given I am on the Host details page
 		And I hover over the "Report" menu
 		When I click "Schedule reports"
@@ -165,14 +165,17 @@ Feature: Scheduled reports
 		When I select "SLA report" from "Select report type"
 		Then "Select report" should have option "saved test report" waiting patiently
 		When I select "saved test report" from "Select report"
-		And I select "Week" from "every_text"
+		And I select "Month" from "every_text"
+		And I choose "sch-first-day-month"
+		And I enter "2" into "every_no"
 		And I enter "dev@op5.com" into "Recipients"
 		And I enter "This report comes from a cuke test. If the test worked, it would have been deleted, so if you're reading this, you've got work to do to fix tests. Chop, chop!" into "Description"
 		And I select "Yes" from "Attach description"
 		And I click "Save"
 		Then I shouldn't see "There are no scheduled SLA reports"
-		And I should see "saved_test_report_Weekly.pdf"
+		And I should see "saved_test_report_Monthly.pdf"
 		And I should see "dev@op5.com"
+		And I should see "Every 2 months on the first day of month at 12:00"
 
 	@reports
 	Scenario: View scheduled SLA report

--- a/modules/reports/models/scheduled_reports.php
+++ b/modules/reports/models/scheduled_reports.php
@@ -437,13 +437,19 @@ SQL;
 				}
 
 				$report_on = json_decode($row->report_on);
-				$day_of_week = $report_on->day;  # 1-7 (or 'last' for last day of month)
+				$day_of_week = $report_on->day;  # 1-7, last, first
 
 				$is_report_day = false;
 				if ($day_of_week == 'last') {
 					// Send if this is the last day of the month.
 					$tomorrow = strtotime('+ 1 day', $now->getTimestamp());
 					if (date('n', $tomorrow) != $now->format('n')) {
+						$is_report_day = true;
+					}
+				}
+				elseif ($day_of_week == 'first') {
+					// Send if this is the first day of the month.
+					if ($now->format('j') == '1') {
 						$is_report_day = true;
 					}
 				}

--- a/modules/reports/src/js/schedule.js
+++ b/modules/reports/src/js/schedule.js
@@ -292,13 +292,19 @@ function create_new_schedule_rows(schedule_id, rep_type, report_name, report_id,
 	}else if(report_period.period_id == 2){
         var report_on =  JSON.parse(report_on);
         if(report_period.no == 1){
-            if(report_on.day != "last"){
+            if(report_on.day == "first") {
+                report_period_text = "Monthly on the first day of month at " + report_time;
+            }
+            else if(report_on.day != "last"){
                 report_period_text = "Monthly on the "+format_num_word(report_on.day_no)+" "+days_name[report_on.day]+" at "+report_time;
             }else{
                 report_period_text = "Monthly on the "+format_num_word(report_on.day_no)+" day of month at "+report_time;
             }
         }else{
-            if(report_on.day != "last"){
+            if(report_on.day == "first") {
+                report_period_text = "Every " + report_period.no + " months on the first day of month at " + report_time;
+            }
+            else if(report_on.day != "last"){
                 report_period_text = "Every "+report_period.no+" months on the "+format_num_word(report_on.day_no)+" "+days_name[report_on.day]+" at "+report_time;
             }else{
                 report_period_text = "Every "+report_period.no+" months on the "+format_num_word(report_on.day_no)+" day of month at "+report_time;

--- a/modules/reports/views/schedule/new_schedule.php
+++ b/modules/reports/views/schedule/new_schedule.php
@@ -96,7 +96,7 @@
 	                        <span wno="0" tag="Sunday">Sun</span>
 	                    </div>
                         <div id="sch-month-opt" class="hide">
-                            <div class="relative"><input id="sch-any-day-month" checked="checked" type="radio" name="sch-month-on" value='{"day_no":"1","day":"1"}'> the
+                            <div class="relative"><label><input id="sch-any-day-month" checked="checked" type="radio" name="sch-month-on" value='{"day_no":"1","day":"1"}'> the</label>
                                 <select name="sch-on-no-box" id="sch-on-no-box" class="rec-on-no-box" value="">
                                     <option value="1">first</option>
                                     <option value="2">second</option>
@@ -114,7 +114,8 @@
                                     <option value="0">Sunday</option>
                                 </select>
                             </div>
-                            <div class="relative"><input id="sch-last-day-month" type="radio" name="sch-month-on" value='{"day_no":"last","day":"last"}'> the last day of the month </div>
+                            <div class="relative"><label><input id="sch-first-day-month" type="radio" name="sch-month-on" value='{"day_no":"first","day":"first"}'> the first day of the month</label></div>
+                            <div class="relative"><label><input id="sch-last-day-month" type="radio" name="sch-month-on" value='{"day_no":"last","day":"last"}'> the last day of the month</label></div>
                         </div>
                     </td>
                 </tr>


### PR DESCRIPTION
Add support for scheduling monthly reports on "the first day of month".
Change one of the schedule report test cases to use the new monthly
option.

This fixes MON-12419.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>
(cherry picked from commit 6b1a8774f0735c44acfa47ba06444180e1237aa4)