### PR TITLE
Remove redundant text in tool tip

### DIFF
--- a/application/languages/en/en.po
+++ b/application/languages/en/en.po
@@ -7379,7 +7379,7 @@ msgstr ""
 
 #: modules/reports/controllers/reports.php:785
 #: modules/reports/controllers/reports.php:785
-msgid "Select which report you want to you want to schedule"
+msgid "Select which report you want to schedule"
 msgstr ""
 
 #: modules/reports/controllers/reports.php:786

--- a/modules/reports/controllers/reports.php
+++ b/modules/reports/controllers/reports.php
@@ -591,7 +591,7 @@ class Reports_Controller extends Base_reports_Controller {
 
 			// new scheduled report
 			'report-type-save' => _("Select what type of report you would like to schedule the creation of"),
-			'select-report' => _("Select which report you want to you want to schedule"), // text ok?
+			'select-report' => _("Select which report you want to schedule"),
 			'report' => _("Select the saved report to schedule"),
 			'interval' => _("Select how often the report is to be produced and delivered"),
 			'recipents' => _("Enter the email addresses of the recipients of the report. To enter multiple addresses, separate them by commas"),


### PR DESCRIPTION
Removes redundant text in a tool tip on the schedule reports page.

Signed-off-by: Daniel Nilsson <dnilsson@itrsgroup.com>