### PR TITLE
Fix tmpname generation

### DIFF
--- a/features/support/configuration.rb
+++ b/features/support/configuration.rb
@@ -61,7 +61,8 @@ module Configuration
       @to_unlink = []
       @to_restore = []
       @nagios_bin = "/opt/monitor/bin/monitor"
-      @root_path = Dir::Tmpname.make_tmpname(Dir.pwd + '/ci_tmp/config_', nil)
+      tmpname = Dir::Tmpname.make_tmpname("", nil)
+      @root_path = File.join(Dir.pwd, 'ci_tmp/config_'+tmpname)
       FileUtils::mkdir_p @root_path
       @objects = {}
     end

--- a/features/support/mock.rb
+++ b/features/support/mock.rb
@@ -59,7 +59,8 @@ module Mock
 
     def save()
       if not active?
-        @file = Dir::Tmpname.make_tmpname(Dir.pwd + '/ci_tmp_mock', nil)
+        tmpname = Dir::Tmpname.make_tmpname("", nil)
+        @file = File.join(Dir.pwd, "ci_tmp_mock" + tmpname)
         FileUtils::mkdir_p File.dirname(@file)
       end
       @mocked_classes.each {|real_class, blk|


### PR DESCRIPTION
Due to an update of something Ruby related on CentOS generation of
tmp directories seems to have failed (missing slashes between prefix).

This commit should fix that by depending on `File.join` instead.

Signed-off-by: Jacob Hansen <jhansen@op5.com>