### PR TITLE
Fix PNG path to avoid 404 errors

### DIFF
--- a/application/views/css/layout.css
+++ b/application/views/css/layout.css
@@ -212,7 +212,7 @@ select.auto {
 }
 
 button, input[type=reset], input[type=submit], input[type=button] {
-  background: #cdcdcd url(images/bg.png) repeat-x;
+  background: #cdcdcd url(default/images/bg.png) repeat-x;
   border: 1px solid #cccccc;
   cursor: pointer;
   -moz-border-radius: 4px;
@@ -248,7 +248,7 @@ input.wide {
 
 .form-dropdown {
   padding: 10px;
-  background: #cdcdcd url(images/bg.png) repeat-x;
+  background: #cdcdcd url(default/images/bg.png) repeat-x;
   border: 1px solid gainsboro;
   display: none;
 }


### PR DESCRIPTION
This relative path to bg.png does not make sense in the
application/views/css directory which this file is in, because there is
no "images" directory here.

Anything using this CSS file will get a 404 error, as it
will try to request an image file that does not exist.

It seems that one of the components that actually use this "non-theme"
is the HTML that is rendered to go into a report via wkhtmltopdf, so you
can reproduce this 404 error by trying the following:

- Generate a PDF report from the GUI by clicking "As PDF" in the top
right corner.
- Grep for 404 in your /var/log/httpd/ssl_access_log and you will see
something like the following:

"GET /monitor/application/views/css/images/bg.png HTTP/1.1" 404 241

It's a problem because it causes wkhtmltopdf to exit with a non-zero
return code, which is visible while debug logging in ninja.log:

"Pdf command /usr/bin/wkhtmltopdf (...) returned 2:"
stderr: Exit with code 2 due to http error: 404 Page not found