### PR TITLE
Xss in dashboard names 7.5

### DIFF
--- a/features/support/configuration.rb
+++ b/features/support/configuration.rb
@@ -61,7 +61,8 @@ module Configuration
       @to_unlink = []
       @to_restore = []
       @nagios_bin = "/opt/monitor/bin/monitor"
-      @root_path = Dir::Tmpname.make_tmpname(Dir.pwd + '/ci_tmp/config_', nil)
+      tmpname = Dir::Tmpname.make_tmpname("", nil)
+      @root_path = File.join(Dir.pwd, 'ci_tmp/config_'+tmpname)
       FileUtils::mkdir_p @root_path
       @objects = {}
     end

--- a/features/support/mock.rb
+++ b/features/support/mock.rb
@@ -59,7 +59,8 @@ module Mock
 
     def save()
       if not active?
-        @file = Dir::Tmpname.make_tmpname(Dir.pwd + '/ci_tmp_mock', nil)
+        tmpname = Dir::Tmpname.make_tmpname("", nil)
+        @file = File.join(Dir.pwd, "ci_tmp_mock" + tmpname)
         FileUtils::mkdir_p File.dirname(@file)
       end
       @mocked_classes.each {|real_class, blk|

--- a/modules/widgets/controllers/tac.php
+++ b/modules/widgets/controllers/tac.php
@@ -270,7 +270,7 @@ class Tac_Controller extends Ninja_Controller {
 			/* @var $user User_Model */
 			$dashboard = new Dashboard_Model();
 			$dashboard->set_username( $user->get_username() );
-			$dashboard->set_name( $this->input->post( 'name' ) );
+			$dashboard->set_name( html::specialchars($this->input->post( 'name' ) ));
 			$dashboard->set_layout( $this->input->post( 'layout', '3,2,1' ) );
 			$dashboard->save();
 			$this->template = new View( 'simple/redirect', array( 'target' => 'controller',
@@ -476,7 +476,7 @@ class Tac_Controller extends Ninja_Controller {
 		if($_POST) {
 			$dashboard = $this->_current_dashboard();
 			if ($dashboard->get_can_write()) {
-				$dashboard->set_name( $this->input->post( 'name' ) );
+				$dashboard->set_name( html::specialchars($this->input->post( 'name' ) ));
 				$dashboard->save();
 			}
 			$this->template = new View( 'simple/redirect', array( 'target' => 'controller',
@@ -548,7 +548,7 @@ class Tac_Controller extends Ninja_Controller {
 			'POST',
 			array(
 				new Form_Field_Hidden_Model('dashboard_id'),
-				new Form_Field_HtmlDecorator_Model('Set dashboard "' . $dashboard->get_name() .  '" as login dashboard?')
+				new Form_Field_HtmlDecorator_Model('Set dashboard "' . html::specialchars($dashboard->get_name()) .  '" as login dashboard?')
 			)
 		);
 


### PR DESCRIPTION
This filters input/output on dashboard names for dangerous javascript.

The filter on the input is not needed as ModSec filters that correctly, but I have put it in as a failsafe if modsec is disabled.
If you somehow managed to get a dangerous name in the Merlin database the output filtering should avoid any javascript from executing

This fixes: MON-12468 which is part of the EMCA Pen tests (MON-12205)

I also included a fix done by Jacob Hansen that fixes the test-running.

Signed-off-by: Axel Bolle abolle@itrsgroup.com