### PR TITLE
Change behavior of wkhtmltopdf debug logging

### DIFF
--- a/modules/reports/controllers/base_reports.php
+++ b/modules/reports/controllers/base_reports.php
@@ -110,6 +110,7 @@ abstract class Base_reports_Controller extends Ninja_Controller
 		if (is_resource($process)) {
 			// Render and store output
 			$content = $this->template->render();
+			$this->log->log('debug', "HTML: $content");
 			$this->auto_render = false;
 
 			$filename = $this->type;
@@ -146,7 +147,6 @@ abstract class Base_reports_Controller extends Ninja_Controller
 			if ($return_value != 0) {
 				$this->log->log('debug', "Pdf command " . $command . " returned $return_value:");
 				$this->log->log('debug', "stderr: $err");
-				$this->log->log('debug', "stdout: $out");
 			}
 		} else {
 			$this->log->log('error', "Tried running the following command but was unsuccessful:");


### PR DESCRIPTION
The current behavior is that on failure, STDOUT is debug-logged, which
is bad because STDOUT from wkhtmltopdf is normally a binary blob which
we put into a PDF file. My assumption is that we only care about the
return code and STDERR, we don't want binary stuff in ninja.log.

This change removes debug-logging of STDOUT, and enables debug-logging
of *all* HTML passed to wkhtmltopdf, even when it succeeds. The idea
here is that if you have enabled debug logging, you probably want as
much info as possible regarding what is being passed.

This can be tested by setting level:debug in log.yml, generating a PDF
report and then looking for "HTML:" in ninja.log

The "bug" here is that, for example, once you have written binary to
ninja.log, you can no longer grep this file without extra work.