### PR TITLE
Fix XSS in error msg on broken widget

### DIFF
--- a/modules/widgets/controllers/tac.php
+++ b/modules/widgets/controllers/tac.php
@@ -764,7 +764,7 @@ class Tac_Controller extends Ninja_Controller {
 		// Create new widget at position 0.
 		$widget_model = new Dashboard_Widget_Model();
 		$widget_model->set_dashboard_id($dashboard->get_id());
-		$widget_model->set_name($widget_name);
+		$widget_model->set_name(htmlspecialchars($widget_name, ENT_NOQUOTES));
 		$widget_model->set_position(array(
 			'c' => $cell_num,
 			'p' => 0

--- a/modules/widgets/widgets/dead/dead.php
+++ b/modules/widgets/widgets/dead/dead.php
@@ -29,7 +29,7 @@ class Dead_Widget extends widget_Base {
 		echo '<div class="alert error"><h3>This widget failed to load</h3>';
 		echo '<p>This may be a temporary problem. If the problem persists, please contact your administrator.</p>';
 		if($this->exc !== null && $this->exc->getMessage()) {
-			echo '<p>Additional troubleshooting information: <strong>' . get_class($this->exc) . '</strong><em>(' . $this->exc->getMessage() . ')</em></p>';
+			echo '<p>Additional troubleshooting information: <strong>' . get_class($this->exc) . '</strong><em>(' . htmlspecialchars( $this->exc->getMessage(), ENT_NOQUOTES ) . ')</em></p>';
 			if(!IN_PRODUCTION) {
 				echo "<p>Also displaying full stack trace because <strong>IN_PRODUCTION</strong> is off:</p>";
 				echo "<pre>";


### PR DESCRIPTION
This will filter the input to the widgets to dissallow the adding of
dangerous javascript.

This will also filter the output of the widget error handling to prevent
the execution of dangerous javascript

This fixes MON-12469 which is part of the EMCA Pen tests (MON-12205)

Signed-off-by: Axel Bolle <abolle@itrsgroup.com>