### PR TITLE
Pressing 'cancel' on widget settings resets the values

### DIFF
--- a/modules/form/src/js/form.js
+++ b/modules/form/src/js/form.js
@@ -29,6 +29,8 @@ var FormModule = (function () {
 		var editbox = form.closest('.widget-editbox');
 		setTimeout(function() {
 			form.find('.nj-form-option').trigger('change');
+			// Reset hover title on cog wheel icon (edit widget)
+			$( editbox ).prev().prev().find(".widget-editlink").attr("title", $.fn.EasyWidgets.defaults.i18n.editTitle);
 			//cancel button click event to show widget content
 			editbox.hide();
 			editbox.next('.widget-content').show();

--- a/modules/form/src/js/form.js
+++ b/modules/form/src/js/form.js
@@ -30,7 +30,7 @@ var FormModule = (function () {
 		setTimeout(function() {
 			form.find('.nj-form-option').trigger('change');
 			// Reset hover title on cog wheel icon (edit widget)
-			$( editbox ).parent().find(".widget-editlink").attr("title", $.fn.EasyWidgets.defaults.i18n.editTitle);
+			$( editbox ).parent().find('.widget-editlink').attr('title', $.fn.EasyWidgets.defaults.i18n.editTitle);
 			//cancel button click event to show widget content
 			editbox.hide();
 			editbox.next('.widget-content').show();

--- a/modules/form/src/js/form.js
+++ b/modules/form/src/js/form.js
@@ -30,7 +30,7 @@ var FormModule = (function () {
 		setTimeout(function() {
 			form.find('.nj-form-option').trigger('change');
 			// Reset hover title on cog wheel icon (edit widget)
-			$( editbox ).prev().prev().find(".widget-editlink").attr("title", $.fn.EasyWidgets.defaults.i18n.editTitle);
+			$( editbox ).parent().find(".widget-editlink").attr("title", $.fn.EasyWidgets.defaults.i18n.editTitle);
 			//cancel button click event to show widget content
 			editbox.hide();
 			editbox.next('.widget-content').show();

--- a/modules/lsfilter/widgets/bignumber/bignumber.php
+++ b/modules/lsfilter/widgets/bignumber/bignumber.php
@@ -259,6 +259,19 @@ class bignumber_Widget extends widget_Base {
 				unset($settings['service']);
 			}
 		}
+		// defining an array for the columns in bignumber widget storing integers
+		// to be able to cast the values which are always string since the data
+		// comes from a JSON object
+		$widget_integer_columns = array(
+			'main_filter_id' => 'integer',
+			'selection_filter_id' => 'integer',
+			'selection_filter_id' => 'integer',
+			'refresh_interval' => 'integer'
+		);
+
+		foreach($widget_integer_columns as $key => $variable_type) {
+			settype($settings[$key], $variable_type);
+		}
 
 		$form_model->set_values($settings);
 		$form_model->set_optional(array('title', 'refresh_interval'));

--- a/modules/widgets/src/js/jquery.easywidgets.js
+++ b/modules/widgets/src/js/jquery.easywidgets.js
@@ -624,7 +624,7 @@
             confirmMsg: 'Remove this widget?',
 
             // Widget cancel edit link title
-            cancelEditTitle: 'Cancel edition',
+            cancelEditTitle: 'Cancel editing',
 
             // Widget extend link title
             extendTitle: 'Extend this widget',

--- a/modules/widgets/src/js/tac.js
+++ b/modules/widgets/src/js/tac.js
@@ -358,6 +358,9 @@ function widget(key) {
 	 */
 widget.prototype.save_settings_delayed = function() {
 	var self = this;
+	// Reset hover title
+	$(this["header"]).find(".widget-editlink").attr("title", $.fn.EasyWidgets.defaults.i18n.editTitle );
+
 	if (this.save_settings_timer)
 		clearTimeout(this.save_settings_timer);
 	this.set_loading(true);
@@ -495,7 +498,10 @@ widget.prototype.update_widget = function() {
 				var title = self.title_element;
 				if (data.custom_title) {
 					title.text(data.custom_title);
-					self.form.find('*[name="title"]').val(data.custom_title);
+					// only update widget title when the title field doesn´t have focus
+					if(document.activeElement.id != self.form.find('*[name="title"]').attr("id") ) {
+						self.form.find('*[name="title"]').val(data.custom_title);
+					}
 				} else {
 					title.text(data.title);
 				}

--- a/modules/widgets/src/js/tac.js
+++ b/modules/widgets/src/js/tac.js
@@ -359,7 +359,7 @@ function widget(key) {
 widget.prototype.save_settings_delayed = function() {
 	var self = this;
 	// Reset hover title
-	$(this["header"]).find(".widget-editlink").attr("title", $.fn.EasyWidgets.defaults.i18n.editTitle );
+	$(this['header']).find('.widget-editlink').attr('title', $.fn.EasyWidgets.defaults.i18n.editTitle );
 
 	if (this.save_settings_timer)
 		clearTimeout(this.save_settings_timer);


### PR DESCRIPTION
This change sets the selected option value in widget menu-list (select item).

-Fixing english translation
-When pressing Save or Cancel on widget resets default hover title on cog icon (edit widget)
-If the user is editing the widgets title and the widget updates throu ajax the title field does not update

Part of MONUI-189

Signed-off-by: Erling Larsson
<elarsson@itrsgroup.com>