### PR TITLE
Add scpecific version of racc gem

### DIFF
--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -17,7 +17,7 @@ post:
 
     # Install cucumber and run tests
     if [ -f /usr/bin/systemctl ]; then
-      gem install cucumber:1.3.6 websocket-driver:0.7.0 nokogiri:1.6.0 rack:1.6.5 rack-test:0.7.0 capybara:2.1.0 public_suffix:2.0.5 xpath:2.0 rspec:2.14.1 parallel:1.13.0 parallel_tests:2.23.0 syntax:1.0.0 cliver:0.3.2 --no-document
+      gem install cucumber:1.3.6 racc:1.4.15 websocket-driver:0.7.0 nokogiri:1.6.0 rack:1.6.5 rack-test:0.7.0 capybara:2.1.0 public_suffix:2.0.5 xpath:2.0 rspec:2.14.1 parallel:1.13.0 parallel_tests:2.23.0 syntax:1.0.0 cliver:0.3.2 --no-document
       gem install poltergeist:1.11.0 -no-document --ignore-dependencies
     else
       gem2.0 install cucumber:1.3.6 websocket-driver:0.7.0 nokogiri:1.6.0 rack:1.6.5 rack-test:0.7.0 capybara:2.1.0 public_suffix:2.0.5 xpath:2.0 rspec:2.14.1 parallel:1.13.0 parallel_tests:2.23.0 syntax:1.0.0 cliver:0.3.2 --no-rdoc --no-ri


### PR DESCRIPTION
Builds started to fail due to errors when installing ruby gems.
Adding a specific version of the racc gem to be installed, 1.4.15
instead of the latest version 1.5.2 seemd to resolve the issue.

Signed-off-by: Daniel Nilsson <dnilsson@itrsgroup.com>