### PR TITLE
Change strotime input to correctly render 'last week'

### DIFF
--- a/application/helpers/time.php
+++ b/application/helpers/time.php
@@ -106,8 +106,8 @@ class time
 			       $time_end = $now;
 			       break;
 			case 'lastweek':
-			       $time_start = strtotime('monday last week', strtotime('midnight -1 sec', $now));
-			       $time_end = strtotime('monday', strtotime('midnight -1 sec', $now));
+			       $time_start = strtotime('monday last week 00:00:00');
+			       $time_end = strtotime('sunday last week 23:59:59');
 			       break;
 			case 'thismonth':
 			       $time_start = strtotime('midnight '.$year_now.'-'.$month_now.'-01');


### PR DESCRIPTION
This works fine on mondays and tuesdays, but breaks for all other days
of the week, likely due to the 'midnight -1 sec' rescuing monday and
tuesday by actually making them sunday and monday, but the 'monday'
passed for time_end then becomes monday next week, causing the report to
show everything up until now.

This commit changes the overly verbose strtotime inputs to something
that hopefully more accurately should reflect "last week" regardless of
what day of the week it is.

For testing/reproduction, I suggest disabling NTP and manually changing
the OS time, then refreshing a report to see how it changes with the
days.

This fixes MON-12548 which has more information in Jira.