### PR TITLE
Show parents and children in extinfo view

### DIFF
--- a/features/monitoring_host.feature
+++ b/features/monitoring_host.feature
@@ -198,11 +198,35 @@ Feature: Monitoring Host
 
 		Given I have these mocked hosts
 			| name       | childs                   |
-			| Babaruajan | Childbaba               |
-			| Childbaba |                          |
+			| Babaruajan | Childbaba                |
+			| Childbaba  |                          |
 
 		And I visit the object details page for host "Babaruajan"
-		Then I should see "Parentbaba"
+		Then I should see "Childbaba"
+
+	@MON-9844
+	Scenario: Host object collapses >3 parents
+
+		Given I have these mocked hosts
+			| name       | parents                     |
+			| Babaruajan | P1host,P2host,P3host,P4host |
+			| P1host     |                             |
+			| P2host     |                             |
+			| P3host     |                             |
+			| P4host     |                             |
+
+		And I visit the object details page for host "Babaruajan"
+		Then I should not see "P1host"
+
+	@MON-9844
+	Scenario: Host object shows group
+
+		Given I have these mocked hosts
+			| name       | groups                   |
+			| Babaruajan | Babagroup                |
+
+		And I visit the object details page for host "Babaruajan"
+		Then I should see "Babagroup"
 
 	Scenario: Host object details displays flapping banner
 

--- a/features/monitoring_host.feature
+++ b/features/monitoring_host.feature
@@ -216,7 +216,7 @@ Feature: Monitoring Host
 			| P4host     |                             |
 
 		And I visit the object details page for host "Babaruajan"
-		Then I should not see "P1host"
+		Then I should see "4 parents"
 
 	@MON-9844
 	Scenario: Host object shows group

--- a/features/monitoring_host.feature
+++ b/features/monitoring_host.feature
@@ -217,6 +217,7 @@ Feature: Monitoring Host
 
 		And I visit the object details page for host "Babaruajan"
 		Then I should see "4 parents"
+		And I shouldn't see "P1host"
 
 	@MON-9844
 	Scenario: Host object shows group

--- a/features/monitoring_host.feature
+++ b/features/monitoring_host.feature
@@ -182,12 +182,24 @@ Feature: Monitoring Host
 		And I visit the object details page for host "Babaruajan"
 		Then I should see "IN SCHEDULED DOWNTIME"
 
+	@MON-9844
 	Scenario: Host object shows parent
 
 		Given I have these mocked hosts
 			| name       | parents                  |
 			| Babaruajan | Parentbaba               |
 			| Parentbaba |                          |
+
+		And I visit the object details page for host "Babaruajan"
+		Then I should see "Parentbaba"
+
+	@MON-9844
+	Scenario: Host object shows child
+
+		Given I have these mocked hosts
+			| name       | childs                   |
+			| Babaruajan | Childbaba               |
+			| Childbaba |                          |
 
 		And I visit the object details page for host "Babaruajan"
 		Then I should see "Parentbaba"

--- a/features/monitoring_host.feature
+++ b/features/monitoring_host.feature
@@ -182,6 +182,16 @@ Feature: Monitoring Host
 		And I visit the object details page for host "Babaruajan"
 		Then I should see "IN SCHEDULED DOWNTIME"
 
+	Scenario: Host object shows parent
+
+		Given I have these mocked hosts
+			| name       | parents                  |
+			| Babaruajan | Parentbaba               |
+			| Parentbaba |                          |
+
+		And I visit the object details page for host "Babaruajan"
+		Then I should see "Parentbaba"
+
 	Scenario: Host object details displays flapping banner
 
 		Given I have these mocked hosts

--- a/modules/monitoring/views/extinfo/components/banners/children.php
+++ b/modules/monitoring/views/extinfo/components/banners/children.php
@@ -1,0 +1,23 @@
+<?php
+
+$childs = $object->get_childs();
+$table = $object->get_table();
+$name = $object->get_name();
+$child_count = count($childs);
+
+if ($child_count) {
+	if ($child_count <= 3) {
+		echo '<li>';
+		echo "<h3>Children:</h3>";
+			foreach ($childs as $child) {
+                echo "<p><a href=\"" . listview::querylink("[{$table}] name=\"{$child}\"") . "\">{$child}</a></p>";
+			}
+		echo '</li>';
+	}
+	elseif ($child_count > 3) {
+		echo '<li>';
+		echo "<h3>Children:</h3>";
+        echo "<p><a href=\"" . listview::querylink("[{$table}] parents >=\"{$name}\"") . "\">{$child_count} parents</a></p>";
+		echo '</li>';
+	}
+}

--- a/modules/monitoring/views/extinfo/components/banners/membership.php
+++ b/modules/monitoring/views/extinfo/components/banners/membership.php
@@ -2,13 +2,21 @@
 
 $groups = $object->get_groups();
 $group_table = ($object->get_table() === 'services') ? 'servicegroups' : 'hostgroups';
+$group_count = count($groups);
 
-if (count($groups)) {
-	echo '<li>';
-	echo "<h3>Member of:</h3>";
-	foreach ($groups as $group) {
-		echo "<p><a href='" . listview::querylink('[' . $group_table . '] name="' . $group . '"') . "'>$group</a></p>";
+if ($group_count) {
+	if ($group_count <= 3) {
+		echo '<li>';
+		echo "<h3>Member of:</h3>";
+		foreach ($groups as $group) {
+			echo "<p><a href=\"" . listview::querylink("[{$group_table}] name=\"{$group}\"") . "\">{$group}</a></p>";
+		}
+		echo '</li>';
 	}
-	echo '</li>';
+	elseif ($group_count > 3) {
+		echo '<li>';
+		echo "<h3>Member of:</h3>";
+		echo "<p><a href=\"" . listview::querylink("[{$group_table}] members >=\"{$name}\"") . "\">{$group_count} groups</a></p>";
+		echo '</li>';
+	}
 }
-

--- a/modules/monitoring/views/extinfo/components/banners/membership.php
+++ b/modules/monitoring/views/extinfo/components/banners/membership.php
@@ -2,7 +2,7 @@
 
 $groups = $object->get_groups();
 $group_table = ($object->get_table() === 'services') ? 'servicegroups' : 'hostgroups';
-$name = $object->get_name();
+$name = ($object->get_table() === 'services' ? $object->get_description() : $object->get_name());
 $group_count = count($groups);
 
 if ($group_count) {

--- a/modules/monitoring/views/extinfo/components/banners/membership.php
+++ b/modules/monitoring/views/extinfo/components/banners/membership.php
@@ -2,6 +2,7 @@
 
 $groups = $object->get_groups();
 $group_table = ($object->get_table() === 'services') ? 'servicegroups' : 'hostgroups';
+$name = $object->get_name();
 $group_count = count($groups);
 
 if ($group_count) {

--- a/modules/monitoring/views/extinfo/components/banners/parents.php
+++ b/modules/monitoring/views/extinfo/components/banners/parents.php
@@ -1,0 +1,23 @@
+<?php
+
+$parents = $object->get_parents();
+$table = $object->get_table();
+$name = $object->get_name();
+$parent_count = count($parents);
+
+if ($parent_count) {
+	if ($parent_count <= 3) {
+		echo '<li>';
+		echo "<h3>Parents:</h3>";
+			foreach ($parents as $parent) {
+                echo "<p><a href=\"" . listview::querylink("[{$table}] name=\"{$parent}\"") . "\">{$parent}</a></p>";
+			}
+		echo '</li>';
+	}
+	elseif ($parent_count > 3) {
+		echo '<li>';
+		echo "<h3>Parents:</h3>";
+        echo "<p><a href=\"" . listview::querylink("[{$table}] childs >=\"{$name}\"") . "\">{$parent_count} parents</a></p>";
+		echo '</li>';
+	}
+}

--- a/modules/monitoring/views/extinfo/components/statebox.php
+++ b/modules/monitoring/views/extinfo/components/statebox.php
@@ -78,6 +78,16 @@
 		'linkprovider' => $linkprovider
 	))->render(true);
 
+	View::factory('extinfo/components/banners/parents', array(
+		'object' => $object,
+		'linkprovider' => $linkprovider
+	))->render(true);
+
+	View::factory('extinfo/components/banners/children', array(
+		'object' => $object,
+		'linkprovider' => $linkprovider
+	))->render(true);
+
 ?>
 	</ul>
   </div>

--- a/modules/monitoring/views/extinfo/components/statebox.php
+++ b/modules/monitoring/views/extinfo/components/statebox.php
@@ -77,7 +77,7 @@
 		'object' => $object,
 		'linkprovider' => $linkprovider
 	))->render(true);
-
+if ($object->get_table() === 'hosts'){
 	View::factory('extinfo/components/banners/parents', array(
 		'object' => $object,
 		'linkprovider' => $linkprovider
@@ -87,7 +87,7 @@
 		'object' => $object,
 		'linkprovider' => $linkprovider
 	))->render(true);
-
+}
 ?>
 	</ul>
   </div>

--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -28,4 +28,4 @@ post:
     mkdir -p /mnt/logs
     echo "core ulimit: \$(ulimit -c)"
     export CUKE_SCREEN_DIR=/mnt/logs/screenshots
-    cucumber -t ~@skip -t ~@unreliable -t @MON-9844 --strict --format html --out /mnt/logs/cucumber.html --format pretty
+    cucumber -t ~@skip -t ~@unreliable --strict --format html --out /mnt/logs/cucumber.html --format pretty

--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -28,4 +28,4 @@ post:
     mkdir -p /mnt/logs
     echo "core ulimit: \$(ulimit -c)"
     export CUKE_SCREEN_DIR=/mnt/logs/screenshots
-    cucumber -t ~@skip -t ~@unreliable -t @monitoring --strict --format html --out /mnt/logs/cucumber.html --format pretty
+    cucumber -t ~@skip -t ~@unreliable -t @MON-9844 --strict --format html --out /mnt/logs/cucumber.html --format pretty

--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -28,4 +28,4 @@ post:
     mkdir -p /mnt/logs
     echo "core ulimit: \$(ulimit -c)"
     export CUKE_SCREEN_DIR=/mnt/logs/screenshots
-    cucumber -t ~@skip -t ~@unreliable --strict --format html --out /mnt/logs/cucumber.html --format pretty
+    cucumber -t ~@skip -t ~@unreliable -t @monitoring --strict --format html --out /mnt/logs/cucumber.html --format pretty


### PR DESCRIPTION
This commit adds two new views that displays on extinfo if there are
parents or children for the current object. According to Naemon,
services can have parents too, but I can't find this in the GUI so I
guess we only support it for hosts.

In addition, it modifies the behavior of the membership view (box) to
conform with the new behavior of these two new views: 3 or more are
shown, otherwise they are collapsed into one listview link.

This fixes MON-9844