### PR TITLE
Remove references to op5.com

### DIFF
--- a/modules/auth/views/401.php
+++ b/modules/auth/views/401.php
@@ -6,8 +6,8 @@ if (count($messages) > 0) {
 	echo '<p>' . array_shift($messages) . "</p>";
 }
 else {
-	echo "<p>And I don't know why! This could be a bug, and we'd really appreciate it if you'd <a target=\"_blank\" href=\"http://bugs.op5.com\">report it</a> or <a target=\"_blank\" href=\"http://www.op5.com/services/support/\">contact support</a>.</p>";
-	echo "<p>Action was: <b>" . $action . "</b>, please include this information in your bug report/support ticket.</p>";
+	echo "<p>And I don't know why! This could be a bug, and we'd really appreciate it if you'd <a target=\"_blank\" href=\"https://support.itrsgroup.com\">contact support</a>.</p>";
+	echo "<p>Action was: <b>" . $action . "</b>, please include this information in your support ticket.</p>";
 }
 
 if (count($messages) > 0) {

--- a/modules/menu/views/about.php
+++ b/modules/menu/views/about.php
@@ -1,17 +1,15 @@
 <div class="popup-about">
-	<a target="_blank" href="http://www.op5.com">
 		<img class="popup-about-img" src="/ninja/modules/menu/views/itrs-about-logo.png">
-	</a>
   <table class="popup-about-table">
     <tr class="popup-about-row popup-about-row-links">
       <td>
         <a href="https://docs.itrsgroup.com/docs/op5-monitor/">Knowledge Base</a>
       </td>
       <td>
-        <a href="http://www.op5.com">www.op5.com</a>
+        <a href="https://www.itrsgroup.com/products/network-monitoring-op5-monitor">ITRS OP5 Monitor</a>
       </td>
       <td>
-        <a href="http://www.op5.com/support">Support</a>
+        <a href="https://support.itrsgroup.com/">Support</a>
       </td>
     </tr>
   </table>

--- a/modules/reports/controllers/alert_history.php
+++ b/modules/reports/controllers/alert_history.php
@@ -11,7 +11,7 @@ class Alert_history_Controller extends Summary_Controller
 	public function index($input = false)
 	{
 		if (isset($_SESSION['report_err_msg'])) {
-			$this->template->content = _("<h1>You're not authorized to see any hosts, so I can't show you a history of their alerts.</h1>\n<p>But then, you <i>were</i> allowed to log in, so I bet something is broken. Please contact <a href=\"https://www.op5.com/support\">OP5 Support</a> with any information you have.</p>");
+			$this->template->content = _("<h1>You're not authorized to see any hosts, so I can't show you a history of their alerts.</h1>\n<p>But then, you <i>were</i> allowed to log in, so I bet something is broken. Please <a href=\"https://support.itrsgroup.com\">contact support</a> with any information you have.</p>");
 			unset($_SESSION['report_err_msg']);
 		}
 		else {


### PR DESCRIPTION
These are left over references to op5.com which no longer serves a web
site, so I have replaced the links with the ITRS equivalents.

I have also removed the link on the logo in the about popup, since the
exact same link is right below it.