### PR TITLE
Stop HTML escaping quicklink URI

### DIFF
--- a/application/controllers/ajax.php
+++ b/application/controllers/ajax.php
@@ -35,8 +35,20 @@ class Ajax_Controller extends Authenticated_Controller {
 		$setting_info = json_decode($setting, true);
 		$setting_href = array();
 		foreach ($setting_info as $setting_data) {
-			$href = htmlspecialchars($setting_data['href'], ENT_QUOTES, 'UTF-8');
-			$setting_href[] = array('href' => $href);
+			if (array_key_exists('href', $setting_data)) {
+				$href = $setting_data['href'];
+				if (preg_match('/^javascript:/i', $href)) {
+					// This is something we just don't allow.
+					$href = '/';
+				} else {
+					// URL encode certain risky characters.
+					$href = str_replace('"', '%22', $href);
+					$href = str_replace("'", '%27', $href);
+					$href = str_replace('<', '%3C', $href);
+					$href = str_replace('>', '%3E', $href);
+				}
+				$setting_href[] = array('href' => $href);
+			}
 		}
 		$setting = array_replace_recursive($setting_info, $setting_href);
 		return json_encode($setting);


### PR DESCRIPTION
With MON-11283 we started escaping reserved HTML characters in quicklink
URIs, which introduced the issue that it was no longer possible to use
ampersand characters (&) in the URI as they would be escaped (&amp;).
This is bad because it essentially disables the use of query parameters
in quicklinks, something that we frequently use within Monitor itself.
Additionally the escaping happened on both saving and loading of the
data, resulting in double escaped data. And because all quicklinks were
saved together, the more quicklinks you added the more escaped would the
older quicklinks get... In short, a mess.

This commit tries to address the problem by removing the escaping of
HTML characters. We try to maintain the protection against XSS attacks
(which the changes in MON-11283 was targeting) by instead using URL
encoding of certain risky characters in the quicklink URI instead. The
fix tries to target characters that would otherwise allow an attacker to
break out of the HTML attribute and start injecting their own code that
way. We also add in a safety against links starting with the javscript:
prefix.

This is part of MON-11453.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>