### PR TITLE
Complete AuthDriver_Keycloak API and create new users

### DIFF
--- a/src/op5/auth/AuthDriver_Keycloak.php
+++ b/src/op5/auth/AuthDriver_Keycloak.php
@@ -19,12 +19,10 @@ class op5AuthDriver_Keycloak extends op5AuthDriver {
 	private $users = null;
 
 	/**
-	 * Log in an already authenticated Keycloak user
+	 * Log in a user with an OpenID Connect flow towards the Keycloak server.
 	 *
-	 * @param
-	 *        	string username to log in
-	 * @param
-	 *        	string password not used
+	 * @param string $username Not used. Included for API compatibility.
+	 * @param string $password Not used. Included for API compatibility.
 	 * @return User_Model|null
 	 */
 	public function login($username, $password) {
@@ -44,30 +42,45 @@ class op5AuthDriver_Keycloak extends op5AuthDriver {
 		$oidc->authenticate();
 
 		$username = $oidc->requestUserInfo('preferred_username');
+		// TODO: Define the 'grp' key somewhere.
+		// Maybe make it part of the module properties?
+		$groups = $oidc->getVerifiedClaims('grp');
 
 		$this->fetch_users();
 		$user = $this->users->reduce_by('username', $username, '=')->one();
 
-		// Check if user has module membership
-		if (!in_array($this->module->get_modulename(), $user->get_modules(), true)) {
+		if (!$user) {
+			$user = new User_Model(
+				array(
+					'username' => $username,
+					'groups' => $groups,
+					'realname' => $realname ? $realname : $username,
+					'modules' => array($this->module->get_modulename())
+				)
+			);
+			$user->save();
+		} else if (!in_array($this->module->get_modulename(), $user->get_modules(), true)) {
 			throw new OpenIDConnectClientException(
 				_("User '$username' is not configured to login using the module: {$this->module->get_modulename()}")
 			);
+		} else if ($groups != $user->get_groups()) {
+			// This is awkward. The groups don't match between Keycloak and
+			// the local data. We choose Keycloak as our authoritative truth
+			// and reset the local data.
+			// TODO: We should probably not store Keycloak users locally. We
+			// then need to implement the other methods of this class via the
+			// Keycloak API instead.
+			$user->set_groups($groups);
+			$user->save();
 		}
 
 		return $user;
 	}
 
-	private function fetch_users() {
-		if ($this->users) return;
-		$this->users = UserPool_Model::all();
-	}
-
 	/**
-	 * Log out a user, if
+	 * Log out a user on the Keycloak server.
 	 *
-	 * @param $user User_Model
-	 *        	driver-specific logout-routine, if driver requires.
+	 * @param User_Model $user User to log out.
 	 */
 	public function logout($user) {
 		$properties = $this->module->get_properties();
@@ -79,5 +92,80 @@ class op5AuthDriver_Keycloak extends op5AuthDriver {
 		);
 		$redirect = "https://" . $_SERVER['HTTP_HOST'] . "/monitor/index.php/" . Kohana::config('routes.log_in_form');
 		$oidc->signOut(NULL, $redirect);
+	}
+
+	/**
+	 * Given a list of groups, return an associative array with groups as
+	 * keys and a boolean if group is available in the backend. If it is
+	 * unknown if the user is available, the field is unset.
+	 *
+	 * If driver supports multiple backends, the extra auth_method can be set to
+	 * the backend. Otherwise, a superset is should given of all backends
+	 *
+	 * @param array $grouplist List of groups to check
+	 * @return array Associative array of the groups in $grouplist as keys,
+	 *               boolean as values
+	 */
+	public function groups_available(array $grouplist) {
+
+		$users = $this->get_keycloak_users();
+		$groups = array();
+
+		foreach ($users as $user) {
+			foreach ($user->get_groups() as $group) {
+				$groups[$group] = $group;
+			}
+		}
+
+		$result = array();
+		foreach ($grouplist as $group) {
+			if (substr($group, 0, 5) == 'user_') {
+				$name = substr($group, 5);
+				$user = $users->reduce_by('username', $name, '=')->one();
+				$result[$group] = (boolean) $user;
+			} else {
+				$result[$group] = isset($groups[$group]);
+			}
+		}
+		return $result;
+	}
+
+	/**
+	 * Given a username, return a list of it's groups.
+	 * Useful when giving permissions to a user.
+	 *
+	 * @param string $username User to search for
+	 * @return array A list of groups
+	 */
+	public function groups_for_user($username) {
+		$users = $this->get_keycloak_users();
+		$user = $users->reduce_by('username', $username, '=')->one();
+		if (!$user) {
+			return array();
+		}
+		return $user->get_groups();
+	}
+
+	/**
+	 * Returns the amount of users configured using this driver.
+	 *
+	 * @return int The usercount
+	 */
+	public function get_user_count () {
+		$users = $this->get_keycloak_users();
+		return count($users);
+	}
+
+	private function fetch_users() {
+		if ($this->users) return;
+		$this->users = UserPool_Model::all();
+	}
+
+	private function get_keycloak_users() {
+		$this->fetch_users();
+		$modulename = $this->module->get_modulename();
+		return array_values(array_filter($this->users, function ($u) {
+			return in_array($modulename, $u->get_modules(), true);
+		}));
 	}
 }


### PR DESCRIPTION
This commit cleans up the AuthDriver_Keycloak class. We make a concious
decision to include Keycloak users in the local user data stored on
file. We do this to simplify the implementation of the other methods
expected in the AuthDriver API, which are also implemented with this
commit (basically copy pasted from the Default driver, with the
exception that we only look at Keycloak users).

With this commit we also create Keycloak users that does not already
exist as local users. This relies on Keycloak including the "grp" claim
that includes the group memberships the user should be created with.

This is part of MON-12654.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>