### PR TITLE
Fix legacy password handling on PHP 7

### DIFF
--- a/features/step_definitions/status.rb
+++ b/features/step_definitions/status.rb
@@ -8,13 +8,13 @@ end
 # Because all our projects have their own helptext implementation...
 Then /^all helptexts should be defined$/ do
   all(:css, '*[data-popover]', :visible => true).each { | elem |
-    elem.trigger(:mouseover)
+    elem.hover
     sleep(1)
     page.should have_css(".lib-popover-tip", :visible => true)
     # "This helptext (%s) is not translated yet" is only printed by convention, but it appears we follow it
     page.should have_no_content "This helptext"
     find(".lib-popover-tip", :visible => true).text.length.should_not be 0
-    elem.trigger(:mouseleave)
+    page.find('body').hover
     page.should have_selector('.lib-popover-tip', visible: false)
   }
 end

--- a/src/op5/auth/AuthDriver_Default.php
+++ b/src/op5/auth/AuthDriver_Default.php
@@ -188,8 +188,8 @@ class op5AuthDriver_Default extends op5AuthDriver {
 			return base64_encode(sha1($pass, true)) === $hash;
 
 		case 'crypt':
-			// ... crypt() encrypted
-			return crypt($pass, $hash) === $hash;
+			// ... crypt() or password_hash() encrypted
+			return password_verify($pass, $hash);
 
 		case 'plain':
 			// ... plaintext (stupid, but true)


### PR DESCRIPTION
- Replace use of Capybara::Node::Element.trigger: This fixes a problem in the op5reports tests.
- Use password_verify: This is not related to op5reports but resolves a password issue I discovered while troubleshooting.

See commit messages for details.