### PR TITLE
Replace use of Capybara::Node::Element.trigger

### DIFF
--- a/features/step_definitions/status.rb
+++ b/features/step_definitions/status.rb
@@ -8,13 +8,13 @@ end
 # Because all our projects have their own helptext implementation...
 Then /^all helptexts should be defined$/ do
   all(:css, '*[data-popover]', :visible => true).each { | elem |
-    elem.trigger(:mouseover)
+    elem.hover
     sleep(1)
     page.should have_css(".lib-popover-tip", :visible => true)
     # "This helptext (%s) is not translated yet" is only printed by convention, but it appears we follow it
     page.should have_no_content "This helptext"
     find(".lib-popover-tip", :visible => true).text.length.should_not be 0
-    elem.trigger(:mouseleave)
+    page.find('body').hover
     page.should have_selector('.lib-popover-tip', visible: false)
   }
 end


### PR DESCRIPTION
The trigger method is not supported with the Selenium driver so we use
the hover method instead.

This only seems to affect the tests for `monitor-op5reports`.