### PR TITLE
Fix invalid use of count() for string length

### DIFF
--- a/modules/reports/controllers/schedule.php
+++ b/modules/reports/controllers/schedule.php
@@ -178,7 +178,7 @@ class Schedule_Controller extends Authenticated_Controller
 				return false;
 			}
 		}
-		$extension = substr($opt_obj['filename'], count($opt_obj['filename'])-5);
+		$extension = strrchr($opt_obj['filename'], '.');
 		if ($extension == '.pdf')
 			$report['output_format'] = 'pdf';
 		else if ($extension == '.csv')


### PR DESCRIPTION
This fixes the "send report now" action for scheduled reports, where
ninja/Kohana dies with exception due to the PHP warning:
  count(): Parameter must be an array or an object that implements Countable

Fixes MON-12833.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>