### PR TITLE
Fix reported vulnerabilities

### DIFF
--- a/modules/auth/controllers/auth.php
+++ b/modules/auth/controllers/auth.php
@@ -61,6 +61,10 @@ class Auth_Controller extends Chromeless_Controller {
 		 */
 		if ($auth->logged_in()) {
 			$requested_uri = $this->input->get('uri', Kohana::config('routes.logged_in_default'));
+			// Prevent attempts that would redirect us to a different host.
+			if (strpos($requested_uri, '://') !== FALSE && strpos($requested_uri, url::base()) !== 0) {
+			    $requested_uri = Kohana::config('routes.logged_in_default');
+			}
 			return url::redirect($requested_uri);
 		}
 

--- a/modules/reports/models/scheduled_reports.php
+++ b/modules/reports/models/scheduled_reports.php
@@ -37,7 +37,7 @@ class Scheduled_reports_Model extends Model
 
 		$row = $res->current();
 		$report_type_id = $row->id;
-		$sql = "DELETE FROM scheduled_reports WHERE report_type_id=".$report_type_id." AND report_id=".$id;
+		$sql = "DELETE FROM scheduled_reports WHERE report_type_id=".$db->escape($report_type_id)." AND report_id=".$db->escape($id);
 		try {
 			$db->query($sql);
 		} catch (Kohana_Database_Exception $e) {
@@ -74,7 +74,7 @@ class Scheduled_reports_Model extends Model
 				scheduled_report_periods rp,
 				saved_reports r
 			WHERE
-				rt.identifier='".$type."' AND
+				rt.identifier=".$db->escape($type)." AND
 				sr.report_type_id=rt.id AND
 				rp.id=sr.period_id AND
 				sr.report_id=r.id".$sql_xtra."
@@ -205,9 +205,9 @@ class Scheduled_reports_Model extends Model
 
 		if ($id) {
 			// UPDATE
-			$sql = "UPDATE scheduled_reports SET ".self::USERFIELD."=".$db->escape($user).", report_type_id=".$rep_type.", report_id=".$saved_report_id.", recipients=".$db->escape($recipients).", period_id=".$period.", filename=".$db->escape($filename).", description=".$db->escape($description).", local_persistent_filepath = ".$db->escape($local_persistent_filepath).", attach_description = ".$db->escape($attach_description)." WHERE id=".$id;
+			$sql = "UPDATE scheduled_reports SET ".self::USERFIELD."=".$db->escape($user).", report_type_id=".$db->escape($rep_type).", report_id=".$db->escape($saved_report_id).", recipients=".$db->escape($recipients).", period_id=".$db->escape($period).", filename=".$db->escape($filename).", description=".$db->escape($description).", local_persistent_filepath = ".$db->escape($local_persistent_filepath).", attach_description = ".$db->escape($attach_description)." WHERE id=".$db->escape($id);
 		} else {
-			$sql = "INSERT INTO scheduled_reports (".self::USERFIELD.", report_type_id, report_id, recipients, period_id, filename, description, local_persistent_filepath, attach_description, report_time, report_on, report_period)VALUES(".$db->escape($user).", ".$rep_type.", ".$saved_report_id.", ".$db->escape($recipients).", ".$period.", ".$db->escape($filename).", ".$db->escape($description).", ".$db->escape($local_persistent_filepath).", ".$db->escape($attach_description).", '".$report_time."', '".$report_on."', '".$report_period."' )";
+			$sql = "INSERT INTO scheduled_reports (".self::USERFIELD.", report_type_id, report_id, recipients, period_id, filename, description, local_persistent_filepath, attach_description, report_time, report_on, report_period)VALUES(".$db->escape($user).", ".$db->escape($rep_type).", ".$db->escape($saved_report_id).", ".$db->escape($recipients).", ".$db->escape($period).", ".$db->escape($filename).", ".$db->escape($description).", ".$db->escape($local_persistent_filepath).", ".$db->escape($attach_description).", ".$db->escape($report_time).", ".$db->escape($report_on).", ".$db->escape($report_period).")";
 
 		}
 
@@ -234,11 +234,11 @@ class Scheduled_reports_Model extends Model
 	 */
 	static function update_report_field($id=false, $field=false, $value=false)
 	{
-		$id = (int)$id;
-		$field = trim($field);
-		$value = trim($value);
 		$db = Database::instance();
-		$sql = "UPDATE scheduled_reports SET ".$field."= ".$db->escape($value)." WHERE id=".$id;
+		$id = (int)$id;
+		$field = $db->escape_column(trim($field));
+		$value = $db->escape(trim($value));
+		$sql = "UPDATE scheduled_reports SET {$field}={$value} WHERE id={$id}";
 		try {
 			$res = $db->query($sql);
 		} catch (Kohana_Database_Exception $e) {


### PR DESCRIPTION
* Prevent login from redirecting to unknown sites

    The login page allows us to set a `uri` query parameter to an address
    where the user will be redirected after a successful login (or directly
    redirected if already logged in). This commit limits this feature to
    only work for pages on the same site. Attempts at redirecting to a
    different site will instead be redirected to the default start page.

    This type of open redirects could be used in phishing attacks, so it's
    safer to disallow it. There doesn't appear to be any use cases in
    Monitor that would warrant a redirect outside the site, afaict.

    If we wanted to be even more rigid we could probably implement this type
    of check in the `redirect` helper function itself, but then the impact
    becomes much broader and it might break some valid use case out there.
    So i have opted to not do that.

* Prevent SQL injections

    This escapes a bunch of variables used in SQL statements, which could
    otherwise be used to perform SQL injection attacks.