### PR TITLE
Update tooltip for listview column config

### DIFF
--- a/application/languages/en/en.po
+++ b/application/languages/en/en.po
@@ -6651,9 +6651,9 @@ msgstr ""
 #: modules/lsfilter/controllers/listview.php:252
 #, php-format
 msgid ""
-"A comma-seperated list of columns visible in the list view for table %s. Use "
-"string \"all\" to see all columns. See documentation for advanced syntax and "
-"column names."
+"A comma-separated list of columns visible in the list view for table %s. Use "
+"string \"default\" to see the default set of columns. See documentation for "
+"advanced syntax and column names."
 msgstr ""
 
 #: modules/lsfilter/views/listview/listview.php:21

--- a/modules/lsfilter/controllers/listview.php
+++ b/modules/lsfilter/controllers/listview.php
@@ -254,7 +254,7 @@ EOF;
 
 		$parts = explode('.',$id);
 		if( count($parts) == 3 && $parts[0] == 'listview' && $parts[1] == 'columns' ) {
-			printf(_("A comma-seperated list of columns visible in the list view for table %s. Use string \"all\" to see all columns. See documentation for advanced syntax and column names."), $parts[2]);
+			printf(_("A comma-separated list of columns visible in the list view for table %s. Use string \"default\" to see the default set of columns. See documentation for advanced syntax and column names."), $parts[2]);
 			return;
 		}
 


### PR DESCRIPTION
There was some confusion around the column config option `all`, and why
it didn't return more columns than the `default` option. This updates
the tooltip to instead refer to `default`, which also matches the
documentation.

It appears that `all` will return the same set of columns as `default`,
which are all those that are defined in the file
modules/monitoring/src/js/lsfilter_renderer_table.js.

This is part of MON-12901.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>