### PR TITLE
MON-9473: Disable Gravatar

### DIFF
--- a/application/views/css/layout.css
+++ b/application/views/css/layout.css
@@ -766,12 +766,12 @@ h1.emote b {
   font-size: 14px;
   color: #fff;
   padding: 0 2px;
-  margin-top: 2px;
 }
 
 .profile-host {
   font-size: 10px;
   color: #d6d6d6;
+  margin-top: -2px;
 }
 
 .menu ul li.profile-info {
@@ -786,10 +786,11 @@ h1.emote b {
 
 .profile-image {
   display: inline-block;
-  padding: 2px 2px 0 2px;
-}
-.profile-image img {
   border-radius: 50%;
+  background: #eaeaea;
+  width: 25px;
+  height: 25px;
+  margin-left: 3px;
 }
 
 .finder {

--- a/application/views/icons/mui-account-icon.svg
+++ b/application/views/icons/mui-account-icon.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"  width="24" height="24" viewBox="0 0 24 24">
+   <path fill="#6C6E6E" d="M12,4A4,4 0 0,1 16,8A4,4 0 0,1 12,12A4,4 0 0,1 8,8A4,4 0 0,1 12,4M12,14C16.42,14 20,15.79 20,18V20H4V18C4,15.79 7.58,14 12,14Z" />
+</svg>

--- a/application/views/profile.php
+++ b/application/views/profile.php
@@ -2,7 +2,7 @@
 	<ul>
 	<li class="profile-info">
 		<div class="profile-image">
-			<img src="<?php echo $avatar; ?>">
+			<img src="/monitor/application/views/icons/mui-account-icon.svg">
 		</div>
 		<div class="profile-name">
 <?php

--- a/application/views/template_header.php
+++ b/application/views/template_header.php
@@ -120,7 +120,6 @@
 
 		if (Auth::instance()->logged_in()) {
 			echo View::factory('profile', array(
-				'avatar' => Auth::instance()->get_user()->get_avatar_url(),
 				'user' => Auth::instance()->get_user(),
 				'host' => gethostname()
 			))->render();

--- a/modules/auth/models/user.php
+++ b/modules/auth/models/user.php
@@ -109,32 +109,6 @@ class User_Model extends BaseUser_Model implements op5MayI_Actor {
 	}
 
 	/**
-	 * Retrieves the users avatar, currently this attempts to retrieve
-	 * it from gravatar.
-	 *
-	 * @param $size The size of the avatar image in pixels
-	 * @return string The URL to access the avatar
-	 */
-	public function get_avatar_url ($size = 28) {
-
-		$email = $this->get_email();
-		if (!$email && class_exists('ContactPool_Model')) {
-			try {
-				$contact = ContactPool_Model::all()->reduce_by('name', $this->get_username(), '=')->one();
-				if ($contact) $email = $contact->get_email();
-			} catch (Exception $e) {
-				/* noop */
-			}
-		}
-
-		$url = 'https://secure.gravatar.com/avatar/';
-		$url .= md5(strtolower(trim($email)));
-		$url .= "?s=$size&d=mm";
-		return $url;
-
-	}
-
-	/**
 	 * Returns a display name of the user, i.e. selects realname if set,
 	 * otherwise the username
 	 *


### PR DESCRIPTION
With this commit the use of Gravatar will be disabled in Monitor 9,
and we use a material UI icon instead.

This is a part of MON-9437

Signed-off-by: Elin Linder <elinder@itrsgroup.com>