### PR TITLE
Version pin selenium-webdrivers

### DIFF
--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -36,7 +36,7 @@ post:
     gem install syntax:1.2.2 --no-document
     gem install cliver --no-document
     gem install webdrivers
-    gem install selenium-webdriver
+    gem install selenium-webdriver:3.142.7
     gem install puffing-billy --no-document
     gem install xpath
 


### PR DESCRIPTION
Selenium-webdrivers was updated to a newer version than our ruby version.
Version-pinning the Selenium-webdrivers gem to ensure tests continue to run.

Signed-off-by: Axel Bolle abolle@itrsgroup.com