### PR TITLE
Fix if statement in custom column list comprehension

### DIFF
--- a/modules/lsfilter/src/js/LSFilterListTableDesc.js
+++ b/modules/lsfilter/src/js/LSFilterListTableDesc.js
@@ -387,7 +387,7 @@ var LSColumnsFilterListVisitor = function(all_columns, all_db_columns, metadata)
 				}, args);
 				for (var i = 0; i < list.length; i++) {
 					subargs.local[name3] = list[i];
-					if (expr7(subargs))
+					if (expr7.evaluator(subargs))
 						result.push(expr1.evaluator(subargs));
 				}
 				return result;


### PR DESCRIPTION
Before this fix a custom column definition like this:

    default, "Groups" = [ grp for grp in groups if grp = "network" ]

Would raise the Javascript error:

    Uncaught TypeError: expr7 is not a function

This has been known for a long time, but not applied since our forebears
felt that the real problem here was the lack of tests. This is still the
case, and tests are not addressed by this commit. We now feel that it is
better to fix a known error, even if we don't have tests to verify that
it doesn't break something else. My personal assessment here is that the
risk for breaking something else is small, based on the limited scope of
this part of the code.

This is part of MON-8831.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>