### PR TITLE
Call showlog without cgi-cfg

### DIFF
--- a/modules/monitoring/helpers/showlog.php
+++ b/modules/monitoring/helpers/showlog.php
@@ -33,13 +33,9 @@ class showlog
 		}
 
 		$limit = 2500;
-		$cgi_cfg = false;
-		$etc_path = System_Model::get_nagios_etc_path();
-		$cgi_cfg = rtrim($etc_path, '/').'/cgi.cfg';
 
 		$args = array(
-			self::get_path(),
-			"--cgi-cfg=$cgi_cfg"
+			self::get_path()
 		);
 
 		foreach ($options as $k => $v) {


### PR DESCRIPTION
The --cgi-cfg argument to merlins showlog tool has been removed per:
https://github.com/ITRS-Group/monitor-merlin/commit/ef15651cc1157119435d577d787cc9a5512e17fa

This caused the event log in ninja to fail to load. In this commit we
remove the use of the --cgi-cfg commit, and relies on the showlog tool
finding the correct naemon configuration file as needed.

Fixes: MON-12943

Signed-off-by: Jacob Hansen <jhansen@op5.com>