### PR TITLE
MONUI-890: Confirmation box should be blue

### DIFF
--- a/application/views/css/layout.css
+++ b/application/views/css/layout.css
@@ -1127,9 +1127,9 @@ h1.emote b {
 
 /* Notification bars */
 
-.info, .notice {
+div.info, div.notice {
   border-color: #50c0e4;
-  color: #50c0e4;
+  background: #50c0e4 !important;
 }
 
 .info.supplementary, .notice.supplementary {


### PR DESCRIPTION
Earlier changes to button design, as a part of Monitor 9, also affected the confirmation box.
With this commit it is once again blue, as it should be.

This fixes MONUI-890

Signed-off-by: Elin Linder <elinder@itrsgroup.com>