### PR TITLE
MONUI-888: Styling issues for filterable move buttons

### DIFF
--- a/application/media/css/jquery.filterable.css
+++ b/application/media/css/jquery.filterable.css
@@ -67,12 +67,14 @@ select.jq-filterable-results {
 
 input[type="button"].jq-filterable-move {
 	position: absolute;
-	right: 2px;
-	top: 3px;
+	right: 0;
+	top: 0;
 	padding: 2px !important;
 	background: #fff !important;
 	border: 1px solid #ccc;
 	margin: 0;
+	color: #555;
+	height: 28px;
 }
 
 .jq-filterable-stats,


### PR DESCRIPTION
After earlier updates, for Monitor 9, the filterable move buttons became invisible and out of place.
With this update we add color to it and put it back in it's place.

This fixes MONUI-888

Signed-off-by: Elin Linder <elinder@itrsgroup.com>