### PR TITLE
Re-generate session id on login

### DIFF
--- a/modules/test/libraries/MockAuth.php
+++ b/modules/test/libraries/MockAuth.php
@@ -61,3 +61,11 @@ class MockAuth extends op5auth
 		return $user;
 	}
 }
+
+/**
+ * A mock implementation of op5Auth, without session_regenerate_id, to prevent
+ * "Headers already sent" errors in unit tests.
+ */
+class MockAuthSession extends op5Auth {
+	protected function session_regenerate_id() {}
+}

--- a/test/AuthDriverDefaultTest.php
+++ b/test/AuthDriverDefaultTest.php
@@ -59,8 +59,11 @@ class AuthDriverDefaultTest extends \PHPUnit\Framework\TestCase {
 		op5objstore::instance()->mock_add( 'op5config',
 		new MockConfig(self::$config) );
 		op5objstore::instance()->mock_add( 'op5log', new MockLog() );
+		op5objstore::instance()->mock_add(
+			'op5auth', new MockAuthSession()
+		);
 
-		$this->auth = new op5Auth();
+		$this->auth = op5auth::instance();
 	}
 
 	public function tearDown() : void {

--- a/test/AuthTest.php
+++ b/test/AuthTest.php
@@ -62,6 +62,9 @@ class AuthTest extends \PHPUnit\Framework\TestCase {
 		$_SESSION = array ('this_should_be_untouched' => 17);
 		// unset the env var
 		$this->assertSame(true, putenv(self::DEPRECATION_ENV_VAR));
+		op5objstore::instance()->mock_add(
+			'op5auth', new MockAuthSession()
+		);
 	}
 
 	public function tearDown() : void {
@@ -75,7 +78,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase {
 	 * states
 	 */
 	public function test_login_logout() {
-		$auth = new op5auth();
+		$auth = op5auth::instance();
 
 		$this->assertEquals(array ('this_should_be_untouched' => 17), $_SESSION);
 		$this->assertEquals(
@@ -151,7 +154,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase {
 	 * library is logged out, but the session remains
 	 */
 	public function test_login_close_logout() {
-		$auth = new op5auth();
+		$auth = op5auth::instance();
 
 		$this->assertEquals(array ('this_should_be_untouched' => 17), $_SESSION);
 		$this->assertEquals(
@@ -249,7 +252,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase {
 	 * out.
 	 */
 	public function test_close_login_logout() {
-		$auth = new op5auth();
+		$auth = op5auth::instance();
 
 		$this->assertEquals(array ('this_should_be_untouched' => 17), $_SESSION);
 		$this->assertEquals(
@@ -328,7 +331,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase {
 		$original_session = $_SESSION;
 
 		/* User should be loaded, session untouched */
-		$auth = new op5auth();
+		$auth = op5auth::instance();
 
 		$this->assertEquals($original_session, $_SESSION);
 		$this->assertEquals(
@@ -402,7 +405,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		/* User should be loaded */
-		$auth = new op5auth();
+		$auth = op5auth::instance();
 
 		$this->assertEquals(
 			array (
@@ -499,7 +502,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase {
 		$original_session = $_SESSION;
 
 		/* User should be loaded */
-		$auth = new op5auth();
+		$auth = op5auth::instance();
 
 		$this->assertEquals(
 			array (

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -45,6 +45,8 @@ op5objstore::instance()->mock_add('op5config', new MockConfig(array(
 require_once ($ninja_base . '/index.php');
 op5objstore::instance()->mock_clear();
 
+require_once ($ninja_base . '/modules/test/libraries/MockAuth.php');
+
 /*
  * If using this bootstrap from a module repository, uncomment those lines
  * below, and update $ninja_base above to the install path of ninja.


### PR DESCRIPTION
Upon successful login, generate a new session id and destroy the old
session. This increases protection against session hijacking.

The patch is largely based on "Example #2 Avoiding lost session by
session_regenerate_id()" at
https://www.php.net/manual/en/function.session-regenerate-id.php

A related change is that we will deploy php configuration on the system
that sets `session.use_strict_mode=1` elsewhere, as that is required for
secure session management.

Fixes MON-12480.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>