### PR TITLE
MONUI-902: Remove resize product image

### DIFF
--- a/modules/auth/views/login.php
+++ b/modules/auth/views/login.php
@@ -57,12 +57,6 @@
 
 	<script>
 		$(document).ready(function(){
-			// Resize the ITRS OP5 Monitor logo just for this page.
-			$(".brand-icon").css({
-				"height": "99px",
-				"width": "203px"
-			});
-
 			// Change the background-color just for this page.
 			$("#content").css("background", "rgb(245,245,245)"); 
 		});


### PR DESCRIPTION
Previously there was a resizing of the logo on the login page.
It is not needed anymore.

This is a part of MONUI-902

Signed-off-by: Elin Linder <elinder@itrsgroup.com>