### PR TITLE
Changing theme crashes ninja

### DIFF
--- a/application/controllers/user.php
+++ b/application/controllers/user.php
@@ -142,7 +142,7 @@ class User_Controller extends Authenticated_Controller {
 						continue;
 					}
 					$current_val = Ninja_setting_Model::fetch_page_setting($cfgkey[0], '*');
-					if (is_object($current_val) && count($current_val)) {
+					if (is_object($current_val) && !empty($current_val)) {
 						$current_values[$cfgkey[0]] = $current_val->setting;
 					} else {
 						$current_values[$cfgkey[0]] = Kohana::config($cfgkey[0]);


### PR DESCRIPTION
Since php 7 we can no longer count() objects to find out if they are populated.
!empty() is used instead.

Signed-off-by: Axel Bolle <abolle@itrsgroup.com>