### PR TITLE
Remove ITRS copyright notice on login screen

### DIFF
--- a/application/views/css/form.css
+++ b/application/views/css/form.css
@@ -17,6 +17,7 @@ form.renderable-login {
 	margin: 0 auto;
 	padding-top: 35px;
 	margin-top: 80px;
+	padding-bottom: 1px;
 }
 
 p.error {

--- a/modules/auth/views/login.php
+++ b/modules/auth/views/login.php
@@ -49,8 +49,6 @@
 		<input type="submit" value="Log in">
 	</fieldset>
 
-	<p class="rights">&#169;2019 ITRS GROUP LTD, ALL RIGHTS RESERVED</p>
-
 	<?php
 		echo form::close()
 	?>


### PR DESCRIPTION
ITRS don't own the full copyright, as ninja is based on the Kohana
framework. Remove notice.

This fixes: MON-12975

Signed-off-by: Jacob Hansen <jhansen@op5.com>