### PR TITLE
Fix host states links

### DIFF
--- a/modules/monitoring/views/extinfo/components/host_states.php
+++ b/modules/monitoring/views/extinfo/components/host_states.php
@@ -3,7 +3,7 @@
 <?php
 $base_set = HostPool_Model::all();
 if ($object->get_table() === 'hostgroups') {
-	$base_set = $base_set->reduce_by('host.groups', $object->get_name(), '>=');
+	$base_set = $base_set->reduce_by('groups', $object->get_name(), '>=');
 } else {
 ?>
 <div class="information-cell">


### PR DESCRIPTION
The host states links on the extinfo page for hostgroups were broken.
They were trying to filter on 'host.groups' rather than just 'groups'.
This resulted in a lsfilter query like this:

    [hosts] host in "<hostgroup_name>" ...

Which results in a 500 error because 'host' is not a recognized field.

This commit changes the links to just 'groups', which makes them work as
expected. It does not address the 500 error, however, because the
efforts involved proved insurmountable by the author.

This is part of MON-12830.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>