### PR TITLE
Redirect / to /monitor/index.php

### DIFF
--- a/op5build/ninja-httpd.conf
+++ b/op5build/ninja-httpd.conf
@@ -4,6 +4,8 @@ Alias /monitor/op5/pnp /opt/monitor/op5/pnp
 Alias /monitor /opt/monitor/op5/ninja
 Alias /ninja /opt/monitor/op5/ninja
 
+RedirectMatch "^/$" "/monitor/index.php"
+
 KeepAlive On
 <Location /monitor>
 	Options -Indexes


### PR DESCRIPTION
With the removal of the OP5 Portal in Monitor 9, we don't have any
landing page on the root path of the Monitor web server. This commit
adds a redirect from the the root web path to the Ninja site, which in
turn is redirected depending on whether there is an active session or
not. A new user browsing to the Monitor server will then typically come
to the Ninja login page instead.

This is part of MON-12622.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>