### PR TITLE
Fix document load order

### DIFF
--- a/modules/monitoring/src/js/backup.js
+++ b/modules/monitoring/src/js/backup.js
@@ -1,5 +1,4 @@
-(function () {
-
+$( document ).ready(function(){
   var baseurl = _site_domain + _index_page + '/';
 
   var nl2br = function(text) {
@@ -185,7 +184,6 @@
       });
 
     return false;
-
   });
+});
 
-})();


### PR DESCRIPTION
Click handler was not loaded at the proper time so it could not intercept the a tag redirect.

Signed-off-by: Axel Bolle <abolle@itrsgroup.com>