### PR TITLE
Configure VM capacity for post install tests

### DIFF
--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -49,3 +49,5 @@ post:
     export CUKE_SCREEN_DIR=/mnt/logs/screenshots
     cucumber -t "not @unreliable" --strict --format html --out /mnt/logs/cucumber.html --format pretty --retry 2 --no-strict-flaky
 
+vm-config: |
+    {"numCPUs": 4, "memoryMB": 8192}


### PR DESCRIPTION
This makes the post-custom step 25% faster, saving us 15 minutes per build.