### PR TITLE
Add feature test for backup/restore config

### DIFF
--- a/features/backup.feature
+++ b/features/backup.feature
@@ -1,0 +1,20 @@
+@backup
+Feature: Backup/Restore configuration
+
+	Background:
+		Given I am logged in as administrator
+		And I check for cookie bar
+
+	Scenario: Create a config backup and then restore to it
+		When I am on address "/index.php/backup"
+		Then I should see "Save your current op5 Monitor configuration"
+		And I click "verify_backup"
+		Then I should see "The current configuration is valid. Do you really want to backup your current configuration?"
+		And I click button "Yes"
+		And I wait for 3 seconds
+		Then I should see regex "backup-.*\.tar\.gz"
+		And I click "Restore Backup"
+		Then I should see "Do you really want to restore this backup?"
+		And I click button "Yes"
+		And I wait for 3 seconds
+		Then I should see regex "The configuration .* has been restored successfully"


### PR DESCRIPTION
Add a test case that does a backup & restore of configuration through
the UI.
This test would reproduce the problem in MON-12985, if monitor-http-api
were installed, which is not normally the case when this test suite
runs.
However, it should fail in case similar issues arise in the future,
where some file included in the backup is not writable by the
unprivileged user that runs restore (httpd process).

Part of MON-12985.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>