### PR TITLE
Only include specific /etc/op5 files in backup (maint/8.x)

### DIFF
--- a/modules/monitoring/controllers/backup.php
+++ b/modules/monitoring/controllers/backup.php
@@ -164,7 +164,7 @@ class Backup_Controller extends Ninja_Controller {
 			System_Model::get_nagios_base_path().'/var/archives', # Isn't this a config backup?
 			System_Model::get_nagios_base_path().'/var/errors',   # Then why would we want these?
 			System_Model::get_nagios_base_path().'/var/traffic',
-			'/etc/op5/*.yml'
+			'/etc/op5/auth*.yml',
 		);
 
 		$backup = array();


### PR DESCRIPTION
Ninjas backup/restore config feature should only backup files that are
written to by the config UI. As /etc/op5 contains files that are not
meant to be modified by users, even less by any UI, they should not be
backed up here.
Restore won't work with files owned by root either, and there are such
files in /etc/op5.
However, everything in /etc/op5 is included in the system level backup
created with the "op5-backup" CLI program.

Fixes MON-13019, MON-12985.

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>
(cherry picked from commit c797a1a3fbf47074df091f625be5f5a21f76a37f)