### PR TITLE
Update Nacoma database to UTF-8

### DIFF
--- a/application/config/database.php
+++ b/application/config/database.php
@@ -64,7 +64,7 @@ $config['nacoma'] = array
 		# that overrides the options above here:
 		'conn_str' => FALSE
 	),
-	'character_set' => 'latin1',
+	'character_set' => 'utf8mb4',
 	'table_prefix'  => '',
 	'object'        => TRUE,
 	'cache'         => FALSE,


### PR DESCRIPTION
This commit updates the Nacoma database config to use the utf8mb4
charset instead of latin1. Other relevant changes are in the Nacoma
repository, but the config of the database connection used needs to be
updated here.

This is part of MON-12319.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>