### PR TITLE
Revert "Tests: add sleep between config file cp..

### DIFF
--- a/features/step_definitions/nagios.rb
+++ b/features/step_definitions/nagios.rb
@@ -54,8 +54,4 @@ And /^I have activated the configuration$/ do
   # inject code between the execution of the background and the actual
   # scenario. I probably just haven't looked hard enough...?
   @configuration.activate
-  # It seems sleep is the most reliable way to ensure the config files
-  # are all in place prior to the scenarios starting. For some reason
-  # this is needed after upgrading to PHP 7.4.
-  sleep(2)
 end


### PR DESCRIPTION
No more flaky tests due to disabling of php-opcache in: https://github.com/ITRS-Group/system-addons-op5-httpd/pull/8

```
334 scenarios (334 passed)
4550 steps (4550 passed)
```
-----------------

This reverts commit 8dccd3d244233f5777691d1423fe0aeb60dfbb49.

It turns out the flaky tests was caused by dnf pulling in the weak
dependency `php-opcache` which wasn't installed on 7.2 before.

We've now disable php-opcache, hence this additional sleep should no
longer be needed.

Part of: MON-12965