### PR TITLE
Don't loop over non-arrays in validate_uri_string

### DIFF
--- a/application/controllers/ajax.php
+++ b/application/controllers/ajax.php
@@ -33,6 +33,9 @@ class Ajax_Controller extends Authenticated_Controller {
 			return $setting;
 		}
 		$setting_info = json_decode($setting, true);
+		if (!is_array($setting_info)) {
+			return $setting;
+		}
 		$setting_href = array();
 		foreach ($setting_info as $setting_data) {
 			if (array_key_exists('href', $setting_data)) {


### PR DESCRIPTION
The purpose of validate_uri_string appears to be cleaning up href values
inside a list of JSON objects, but we are feeding this function all
sorts of values -- including non-JSON data. This commit makes the
validate_uri_string bail and return its argument unchanged, if it cannot
be parsed as a JSON list. This fixes a problem where the refresh rate on
listview pages could not be saved, because of an error in the mentioned
function.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>