### PR TITLE
Fix saving default graph from PNP page

### DIFF
--- a/modules/monitoring/src/js/pnp/pnp.js
+++ b/modules/monitoring/src/js/pnp/pnp.js
@@ -5,7 +5,7 @@ $(document).ready(function () {
 			$(this).append('<td align="right"><a href="#" class="default" title="Make default graph" alt="Make default graph"><img src="' + _site_domain + '/application/views/icons/x16/shield-ok.png"/></a></td>');
 			$(this).find('.default').click(function() {
 				var src = $(this).closest('div').next('div').find('img').attr('src');
-				var match = src.match(/\?(.*)&view=(\d)&source=(\d)/);
+				var match = src.match(/\?(.*)&source=(\d)&view=(\d)/);
 				$.ajax(
 					_site_domain + _index_page + '/pnp/pnp_default/',
 					{


### PR DESCRIPTION
Graphs on the PNP page has a button that lets us save it as the "default
graph". (It is unknown to me what being the default graph actually does,
though.) This functionality was broken since a recent update to
PNP4Nagios that changed the order in which the source and view query
parameters appear in the URL, which is then fixed by this commit. (This
is obviously a very fragile way of getting the data in the first place,
but I'm not going to bother doing more than necessary at this point.)

This is part of MON-13020.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>