### PR TITLE
Make default graph actually do something

### DIFF
--- a/application/src/js/lib.popover.js
+++ b/application/src/js/lib.popover.js
@@ -339,16 +339,51 @@
       host = encodeURIComponent(ns[0]),
       service = "_HOST_";
 
-    if(ns[1]) service = encodeURIComponent(ns[1]);
+    // If a service
+    if (ns[1]) {
+      service = encodeURIComponent(ns[1]);
+    }
 
-    var img = $('<img>').one('load', function(e){
-      Popover.display(img.get(0), target);
-      tooltip.css('width', 'auto');
-    }).one('error', function(e){
-      Popover.display("Could not fetch graph", target);
-    }).attr({
-      src: _pnp_web_path + 'image?host=' + host + '&srv=' + service + '&source=0&view=0'
-    });
+    $.ajax(
+      _site_domain + _index_page + '/pnp/get_pnp_default/',
+      {
+        data: {
+          page: _pnp_web_path + '/image?host=' + host + '&srv=' + service,
+          csrf_token: _csrf_token
+        },
+        success: function (data) {
+          var pnp_settings = JSON.parse(data)
+          var src_string = ""
+          if (pnp_settings) {
+            src_string =  _pnp_web_path +
+                          'image?host=' +
+                          host +
+                          '&srv=' +
+                          service +
+                          `&source=${pnp_settings.source}&view=${pnp_settings.view}`
+          } else {
+            src_string =  _pnp_web_path +
+                          'image?host=' +
+                          host +
+                          '&srv=' +
+                          service +
+                          `&source=0&view=0`
+          }
+          var img = $('<img>').one('load', function (e) {
+            Popover.display(img.get(0), target);
+            tooltip.css('width', 'auto');
+          }).one('error', function (e) {
+            Popover.display("Could not fetch graph", target);
+          }).attr({
+            src: src_string
+          });
+        },
+        error: function () {
+          Popover.display("Popover error", target);
+        },
+        type: 'POST'
+      }
+    );
 
   });
 

--- a/application/src/js/lib.popover.js
+++ b/application/src/js/lib.popover.js
@@ -345,7 +345,7 @@
     }
 
     $.ajax(
-      _site_domain + _index_page + '/pnp/get_pnp_default/',
+      _site_domain + _index_page + '/pnp/get_pnp_default_graph_setting/',
       {
         data: {
           page: _pnp_web_path + '/image?host=' + host + '&srv=' + service,

--- a/modules/monitoring/controllers/pnp.php
+++ b/modules/monitoring/controllers/pnp.php
@@ -58,7 +58,7 @@ class Pnp_Controller extends Authenticated_Controller {
 	/**
 	 * Get graph setting for a specific host/service
 	 */
-	public function get_pnp_default()
+	public function get_pnp_default_graph_setting()
 	{
 
 		/* Ajax calls shouldn't be rendered. This doesn't, because some unknown
@@ -72,9 +72,10 @@ class Pnp_Controller extends Authenticated_Controller {
 
 		if ($pnp_path != '') {
 			$settings = Ninja_setting_Model::fetch_page_setting('default_graph', $page);
+			
+			// Outputs false on no entry found
+			echo $settings->setting;
 		}
-		// Returns false on no entry found
-		echo $settings->setting;
 	}
 
 }

--- a/modules/monitoring/controllers/pnp.php
+++ b/modules/monitoring/controllers/pnp.php
@@ -49,9 +49,32 @@ class Pnp_Controller extends Authenticated_Controller {
 		if ($pnp_path != '') {
 			$source = intval($this->input->post('source', false));
 			$view = intval($this->input->post('view', false));
+			$settings = json_encode(array("source"=>$source, "view"=>$view));
 
-			Ninja_setting_Model::save_page_setting('source', $pnp_path.'/image?'.$param, $source);
-			Ninja_setting_Model::save_page_setting('view', $pnp_path.'/image?'.$param, $view);
+			Ninja_setting_Model::save_page_setting('default_graph', $pnp_path.'/image?'.$param, $settings);
 		}
 	}
+
+	/**
+	 * Get graph setting for a specific host/service
+	 */
+	public function get_pnp_default()
+	{
+
+		/* Ajax calls shouldn't be rendered. This doesn't, because some unknown
+		 * magic doesn't render templates in ajax requests, but for debugging
+		 */
+		$this->auto_render = false;
+
+		$page = $this->input->post('page', false);
+
+		$pnp_path = Kohana::config('config.pnp4nagios_path');
+
+		if ($pnp_path != '') {
+			$settings = Ninja_setting_Model::fetch_page_setting('default_graph', $page);
+		}
+		// Returns false on no entry found
+		echo $settings->setting;
+	}
+
 }

--- a/modules/monitoring/src/js/pnp/pnp.js
+++ b/modules/monitoring/src/js/pnp/pnp.js
@@ -11,8 +11,8 @@ $(document).ready(function () {
 					{
 						data: {
 							param: match[1],
-							view: match[2],
-							source: match[3],
+							source: match[2],
+							view: match[3],
 							csrf_token: _csrf_token
 						},
 						success: function () {


### PR DESCRIPTION
This will introduce a new behavior for the graph button in list views.
When you now hover over the graph icon in a list view a lookup will be done
to see if the setting "default_graph" is set on that particular host. If
set, it will display the corresponding graph from pnp.

Also changed the way we save default_graph in the database. It is now
stored as a single json object instead of 2 separate entries. This
halves database requests when looking them up, due to our ORM.

Implemented a getter for the default_graph value that is to be accessed
via ajax.

Signed-off-by: Axel Bolle <abolle@itrsgroup.com>