### PR TITLE
Revert "Fix saving default graph from PNP page"

### DIFF
--- a/modules/monitoring/src/js/pnp/pnp.js
+++ b/modules/monitoring/src/js/pnp/pnp.js
@@ -5,7 +5,7 @@ $(document).ready(function () {
 			$(this).append('<td align="right"><a href="#" class="default" title="Make default graph" alt="Make default graph"><img src="' + _site_domain + '/application/views/icons/x16/shield-ok.png"/></a></td>');
 			$(this).find('.default').click(function() {
 				var src = $(this).closest('div').next('div').find('img').attr('src');
-				var match = src.match(/\?(.*)&source=(\d)&view=(\d)/);
+				var match = src.match(/\?(.*)&view=(\d)&source=(\d)/);
 				$.ajax(
 					_site_domain + _index_page + '/pnp/pnp_default/',
 					{


### PR DESCRIPTION
This fix should not be made on maint/8.x because the corresponding
changes on monitor-pnp has not happened on Monitor 8.

This is part of MON-13020.

This reverts commit 77f4f43e599ff4e24be852634f86a5a8a398e5c8.