### PR TITLE
Undo config after backup restore

### DIFF
--- a/modules/monitoring/controllers/backup.php
+++ b/modules/monitoring/controllers/backup.php
@@ -236,6 +236,16 @@ class Backup_Controller extends Ninja_Controller {
 			return;
 		}
 
+		proc::open(array('/usr/bin/asmonitor', '/usr/bin/php', '/opt/monitor/op5/nacoma/api/monitor.php', '-a', 'undo_config'), $stdout, $stderr, $status);
+
+		if ($status) {
+			$this->template = json::fail_view(array(
+				"message" => "The configuration '{$file}' has been restored, but it could not be loaded into the database.",
+				"debug" => $stderr
+			));
+			return;
+		}
+
 		$this->template = json::ok_view("The configuration '{$file}' has been restored successfully");
 	}
 


### PR DESCRIPTION
The Backup/Restore feature in Ninja would only restore the configuration
files without touching the Nacoma database. This could result in Nacoma
not matching the actual configuration, if file changes are not detected.
With this commit we run the `undo_config` action in the Nacoma API as
part of the restore, which reloads the config in the database from the 
config files.

This is part of MON-13039.

Signed-off-by: Petter Nyström <pnystrom@itrsgroup.com>