### PR TITLE
op5build: Fix building on RHEL8

### DIFF
--- a/op5build/monitor-ninja.spec
+++ b/op5build/monitor-ninja.spec
@@ -37,11 +37,12 @@ BuildRequires: python2
 BuildRequires: doxygen
 BuildRequires: graphviz
 Requires: python2
-Requires: php >= 5.3
+Requires: php
+Requires: php-cli
 Requires: php-json
 Requires: php-ldap
 Requires: php-pecl-apcu
-BuildRequires: php >= 5.3
+BuildRequires: php-cli
 BuildRequires: php-json
 BuildRequires: shadow-utils
 Requires: php-process
@@ -50,7 +51,7 @@ BuildRequires: php-process
 # For stack trace info
 Requires: psmisc
 Requires: pciutils
-%systemd_requires
+%{?systemd_requires}
 
 Source: %name-%version.tar.gz
 %description


### PR DESCRIPTION
* Explicitly specify php-cli dependency (on php 7.4, php-cli is only a
  weak dependency of php).
* Allow the specfile to parse properly in the case where the systemd
  macros have yet to be installed (RHEL8 mock builds).

Signed-off-by: Aksel Sjögren <asjogren@itrsgroup.com>