### PR TITLE
Set session cookie timeout to 5 minutes

### DIFF
--- a/application/config/cookie.php
+++ b/application/config/cookie.php
@@ -17,7 +17,7 @@ $config['path'] = '/';
  * Lifetime of the cookie. A setting of 0 makes the cookie active until the
  * users browser is closed or the cookie is deleted.
  */
-$config['expire'] = 0;
+$config['expire'] = 300;
 
 /**
  * Set to true, to only allow logging in through HTTPS, or false to allow


### PR DESCRIPTION
Due to security concerns, we have requests on being able to define a
timeout value for inactive sessions so that you get logged out
automatically after a specified amount of time. This commit sets that
timeout to 5 minutes.

Signed-off-by: Erik Sjöström <esjostrom@itrsgroup.com>