### PR TITLE
Change .complete to .always when doing a post request

### DIFF
--- a/modules/monitoring/src/js/extinfo.js
+++ b/modules/monitoring/src/js/extinfo.js
@@ -84,7 +84,7 @@ $(document).on('click','div[data-setting-toggle-command]', function () {
 		}
 	}).fail(function () {
 		Notify.message("Failed to toggle setting.", {type: "error", sticky: true});
-	}).complete(function () {
+	}).always(function () {
 		toggler.removeClass('toggle-waiting');
 	});
 


### PR DESCRIPTION
.complete is deprecated and should not be used. Instead we should use
.always on post requests made by jquery.

This solves: MON-13133
Signed-off-by: Axel Bolle <abolle@itrsgroup.com>