### PR TITLE
Fix dst handling in report tests

### DIFF
--- a/features/step_definitions/capybara.rb
+++ b/features/step_definitions/capybara.rb
@@ -195,8 +195,8 @@ Then /^I should see "([^"]*)", compensating for DST$/ do |string|
   #NOTE: Only works for strings of the form Nd, where N is some integer between
   # 1 and 31, inclusive. FML.
   days = DateTime.strptime(string,"%dd").day
-  was_dst = (DateTime.now - days).to_time.dst?
-  is_dst = DateTime.now.to_time.dst?
+  was_dst = (DateTime.now - days).to_time.localtime.dst?
+  is_dst = DateTime.now.to_time.localtime.dst?
   if was_dst and not is_dst then
     #plus one hour
     string = string + " 1h"


### PR DESCRIPTION
We now handle time using localtime to account for timezones.

Signed-off-by: Axel Bolle <abolle@itrsgroup.com>