### PR TITLE
Reports send now functionality och allow saving to /tmp

### DIFF
--- a/modules/reports/controllers/schedule.php
+++ b/modules/reports/controllers/schedule.php
@@ -192,7 +192,9 @@ class Schedule_Controller extends Authenticated_Controller
 		$process = proc_open($cmd, $pipe_desc, $pipes, DOCROOT);
 		$this->log->log('debug', $cmd);
 		if (is_resource($process)) {
-			fwrite($pipes[0], "\n");
+			# This fwrite does not work when executed via XHR. 
+			# Does not seem to break if removed when running via CLI
+			#fwrite($pipes[0], "\n");
 			fclose($pipes[0]);
 			$out = stream_get_contents($pipes[1]);
 			$err = stream_get_contents($pipes[2]);


### PR DESCRIPTION
The fwrite("\n") seems to no longer be needed. As the PDFs look fine without it. And it was causing issues when using through the web-gui

This is part of: MON-13146