### PR TITLE
Initiate event handlers on Lightbox load

### DIFF
--- a/modules/reports/src/js/lightbox_edit_settings.js
+++ b/modules/reports/src/js/lightbox_edit_settings.js
@@ -46,6 +46,7 @@ $(document).ready(function() {
 		if ( settings.url === edit_settings_url ) {
 			setTimeout(function() {
 				filterable_init();
+				$('.filter-status').on('change', filter_mapping_mapping).each(filter_mapping_mapping);
 				$( ".lightbox-content" ).css({"display": "block"});
 				$('.lightbox-content #header').remove();
 				$('.lightbox-content').find('.filter-status').each(lightbox_filter_mapping_mapping);


### PR DESCRIPTION
The event handler is added to the checkboxes after loading the dom.

Signed-off-by: Axel Bolle <abolle@itrsgroup.com>