### PR TITLE
Fix "last_sent" not being set when sending reports

### DIFF
--- a/modules/reports/models/scheduled_reports.php
+++ b/modules/reports/models/scheduled_reports.php
@@ -240,6 +240,7 @@ class Scheduled_reports_Model extends Model
 			"filename",
 			"local_persistent_filepath",
 			"attach_description",
+			"last_sent"
 		];
 		$column = array_search($field, $allowed_columns, TRUE);
 


### PR DESCRIPTION
The "last_sent" parameter is now being allowed to be set on the scheduled report entry in the database. 
This will fix the issue with Ninja emailing report recipients every minute.

This solves: MON-13188
Signed-off-by: Axel Bolle <abolle@itrsgroup.com>