### PR TITLE
Add --all-nodes option to showlog

### DIFF
--- a/application/views/css/layout.css
+++ b/application/views/css/layout.css
@@ -721,7 +721,7 @@ h1.emote b {
 }
 
 #summary_form .showlog input#Update {
-  margin-top: 130px;
+  margin-top: 160px;
 }
 
 .long_output {

--- a/modules/monitoring/helpers/showlog.php
+++ b/modules/monitoring/helpers/showlog.php
@@ -88,6 +88,11 @@ class showlog
 		if (empty($options['parse_forward'])) {
 			$args[] = '--reverse';
 		}
+
+		if (!empty($options['all_nodes'])) {
+			$args[] = '--all-nodes';
+		}
+
 		# invoke a hard limit in case the user didn't set any.
 		# This will prevent php from exiting with an out-of-memory
 		# error, and will also stop users' browsers from hanging

--- a/modules/monitoring/views/showlog/showlog.php
+++ b/modules/monitoring/views/showlog/showlog.php
@@ -14,6 +14,7 @@
 			<label><?php echo form::checkbox('hide_logrotation', 1, isset($options['hide_logrotation'])).' '._('Hide logrotation messages'); ?></label><br />
 			<?php echo $is_authorized ? '<label>'.form::checkbox('hide_commands', 1, isset($options['hide_commands'])).' '._('Hide external commands').'</label><br />' : ''; ?>
 			<label><?php echo form::checkbox('parse_forward', 1, isset($options['parse_forward'])).' '._('Older entries first'); ?>
+			<label><?php echo form::checkbox('all_nodes', 1, isset($options['all_nodes'])).' '._('Show logs from all nodes'); ?></label><br />
 			</td>
 			<td class="showlog_options">
 				<table>

--- a/modules/monitoring/views/showlog/showlog.php
+++ b/modules/monitoring/views/showlog/showlog.php
@@ -13,7 +13,7 @@
 			<label><?php echo form::checkbox('hide_initial', 1, isset($options['hide_initial'])).' '._('Hide initial and current states'); ?></label><br />
 			<label><?php echo form::checkbox('hide_logrotation', 1, isset($options['hide_logrotation'])).' '._('Hide logrotation messages'); ?></label><br />
 			<?php echo $is_authorized ? '<label>'.form::checkbox('hide_commands', 1, isset($options['hide_commands'])).' '._('Hide external commands').'</label><br />' : ''; ?>
-			<label><?php echo form::checkbox('parse_forward', 1, isset($options['parse_forward'])).' '._('Older entries first'); ?>
+			<label><?php echo form::checkbox('parse_forward', 1, isset($options['parse_forward'])).' '._('Older entries first'); ?></label><br />
 			<label><?php echo form::checkbox('all_nodes', 1, isset($options['all_nodes'])).' '._('Show logs from all nodes'); ?></label><br />
 			</td>
 			<td class="showlog_options">


### PR DESCRIPTION
This commit adds a new command line option --all-nodes to the
showlog tool. This new option will gather logs from all nodes
and create a consolidated list of event logs. Each log is
appended with the node name where the log originated.
A new radio button is added to the event log page to invoke
the new  command line option.

This is part of MON-13186

Signed-off-by: Jerson Dumalaon <jdumalaon@itrsgroup.com>