### PR TITLE
Added quicklink validation to avoid xss attacks

### DIFF
--- a/application/controllers/ajax.php
+++ b/application/controllers/ajax.php
@@ -50,7 +50,17 @@ class Ajax_Controller extends Authenticated_Controller {
 					$href = str_replace('<', '%3C', $href);
 					$href = str_replace('>', '%3E', $href);
 				}
-				$setting_href[] = array('href' => $href);
+				$icon = $setting_data['icon'];
+				$icon = str_replace('(', '', $icon);
+				$icon = str_replace(')', '', $icon);
+				$icon = str_replace('.', '', $icon);
+				$icon = str_replace('=', '', $icon);
+				$icon = htmlspecialchars(trim($icon), ENT_QUOTES);
+
+				$title = $setting_data['title'];
+				$title = htmlspecialchars(trim($title), ENT_QUOTES);
+
+				$setting_href[] = array('href' => $href, 'icon' => $icon, 'title' => $title);
 			}
 		}
 		$setting = array_replace_recursive($setting_info, $setting_href);


### PR DESCRIPTION
Back ported quicklink validation on title and icon details to avoid xss attacks via payload resend.

This commit resolves MON-13209.

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>