### PR TITLE
Change styling on about page links and add divider

### DIFF
--- a/application/views/css/layout.css
+++ b/application/views/css/layout.css
@@ -448,19 +448,27 @@ dd {
   margin: 1% 0;
 }
 
-.popup-about table tr td {
-  text-align: center;
-  width: 20%;
-  max-width: 20%;
-  padding: 0;
+.popup-about-table {
+  margin: 0 10%;
+  padding: 2% 0 0% 0%;
 }
 
-.popup-about table tr:hover td {
-  background: inherit;
+.popup-about-row {
+  display: flex;
 }
 
-.popup-about table {
-  margin: 8px 5%;
+.popup-link{
+  cursor: pointer;
+  margin-right: 2em;
+}
+
+.popup-link:hover{
+  border-bottom: 1px solid #444444;
+  margin-bottom: -1px;
+}
+
+.popup-divider{
+  margin: 2% 10%;
 }
 
 .comments .content {

--- a/modules/menu/views/about.php
+++ b/modules/menu/views/about.php
@@ -1,21 +1,22 @@
-<div class="popup-about">
-		<img class="popup-about-img" src="/ninja/modules/menu/views/itrs_op5_expanded.png">
-  <table class="popup-about-table">
-    <tr class="popup-about-row popup-about-row-links">
-      <td>
+<div class='popup-about'>
+    <img class='popup-about-img' src='/ninja/modules/menu/views/itrs_op5_expanded.png'>
+    <div class='popup-about-table'>
+        <div class='popup-about-row popup-about-row-links'>
+      <span class='popup-link'>
         <a href="<?php echo Kohana::config('product.docs_url'); ?>">Knowledge Base</a>
-      </td>
-      <td>
-        <a href="https://www.itrsgroup.com/products/network-monitoring-op5-monitor">ITRS OP5 Monitor</a>
-      </td>
-      <td>
-        <a onclick="openLicenseInfo()">License Information</a>
-      </td>
-      <td>
+      </span>
+            <span class='popup-link'>
+        <a href='https://www.itrsgroup.com/products/network-monitoring-op5-monitor'>ITRS OP5 Monitor</a>
+      </span>
+            <span class='popup-link'>
+        <a onclick='openLicenseInfo()'>License Information</a>
+      </span>
+            <span class='popup-link'>
         <a href="<?php echo Kohana::config('product.support_url'); ?>">Support</a>
-      </td>
-    </tr>
-  </table>
+      </span>
+        </div>
+    </div>
+    <hr class="popup-divider"></hr>
 <?php
 $data = $about->get_all();
 echo html::get_definition_list($data);


### PR DESCRIPTION
I think something went wrong when some older changes were merged.

This will introduce the old styling changes back.

Signed-off-by: Axel Bolle <abolle@itrsgroup.com>