### PR TITLE
Change the default report period for alert history

### DIFF
--- a/features/alert_history.feature
+++ b/features/alert_history.feature
@@ -45,8 +45,8 @@ Feature: Alert history reports
 	@configuration
 	Scenario: See that host edit settings form content rendered correct
 		When I view a "alert_history" report with these settings:
-		| report_type    | objects       | report_period
-		| hosts          | linux-server1 | forever
+		| report_type    | objects       | report_period	|
+		| hosts          | linux-server1 | forever			|
 		Then "Show all" should be unchecked
 		And "objects" should have option "linux-server1"
 		When I uncheck "Up"
@@ -164,8 +164,8 @@ Feature: Alert history reports
 	@configuration
 	Scenario: See that pagination edit settings form content rendered correct
 		When I view a "alert_history" report with these settings:
-		| report_type    | objects       | report_period
-		| hosts          | win-server1   | forever
+		| report_type    | objects       | report_period	|
+		| hosts          | win-server1   | forever			|
 		And I enter "1" into "Items to show"
 		And I check "Older entries first"
 		And I click "Update"

--- a/features/alert_history.feature
+++ b/features/alert_history.feature
@@ -45,12 +45,11 @@ Feature: Alert history reports
 	@configuration
 	Scenario: See that host edit settings form content rendered correct
 		When I view a "alert_history" report with these settings:
-		| report_type    | objects       |
-		| hosts          | linux-server1 |
+		| report_type    | objects       | report_period
+		| hosts          | linux-server1 | forever
 		Then "Show all" should be unchecked
 		And "objects" should have option "linux-server1"
 		When I uncheck "Up"
-		And select "Forever" from "Reporting period"
 		And I click "Update"
 		Then I shouldn't see "Sven Melander"
 
@@ -165,10 +164,9 @@ Feature: Alert history reports
 	@configuration
 	Scenario: See that pagination edit settings form content rendered correct
 		When I view a "alert_history" report with these settings:
-		| report_type    | objects       |
-		| hosts          | win-server1   |
+		| report_type    | objects       | report_period
+		| hosts          | win-server1   | forever
 		And I enter "1" into "Items to show"
-		And select "Forever" from "Reporting period"
 		And I check "Older entries first"
 		And I click "Update"
 		Then I should see "OK - laa-laa"

--- a/features/alert_history.feature
+++ b/features/alert_history.feature
@@ -38,8 +38,14 @@ Feature: Alert history reports
 	@configuration
 	Scenario: Single host alert history
 		Given I visit the alert history page for host "linux-server1"
+		And I have these additional report data entries on current timestamp:
+			| timestamp           | event_type | flags | attrib | host_name     | service_description | state | hard | retry | downtime_depth | output			|
+			| 2023-01-01 12:00:01 |        801 |  NULL |   NULL | win-server1   |                     |     0 |    1 |     1 |           NULL | OK - Alpha		|
+			| 2023-01-01 12:00:02 |        801 |  NULL |   NULL | linux-server1 |                     |     0 |    1 |     1 |           NULL | OK - Bravo		|
+			| 2023-01-01 12:00:03 |        701 |  NULL |   NULL | win-server1   | PING                |     0 |    1 |     1 |           NULL | OK - Charlie    |
+			| 2023-01-01 12:00:04 |        701 |  NULL |   NULL | win-server1   | PING                |     1 |    0 |     1 |           NULL | ERROR - Mike    |
 		Then I should see "Reporting period: Today"
-		And I should see "No log data recorded during this time"
+		And I should see "OK - Bravo"
 		And I shouldn't see "win-server"
 
 	@configuration

--- a/features/alert_history.feature
+++ b/features/alert_history.feature
@@ -44,7 +44,7 @@ Feature: Alert history reports
 			| 2023-01-01 12:00:02 |        801 |  NULL |   NULL | linux-server1 |                     |     0 |    1 |     1 |           NULL | OK - Bravo		|
 			| 2023-01-01 12:00:03 |        701 |  NULL |   NULL | win-server1   | PING                |     0 |    1 |     1 |           NULL | OK - Charlie    |
 			| 2023-01-01 12:00:04 |        701 |  NULL |   NULL | win-server1   | PING                |     1 |    0 |     1 |           NULL | ERROR - Mike    |
-		Then I should see "Reporting period: Today"
+		Then I should see "Reporting period: Last 24 hours"
 		And I should see "OK - Bravo"
 		And I shouldn't see "win-server"
 

--- a/features/alert_history.feature
+++ b/features/alert_history.feature
@@ -38,8 +38,8 @@ Feature: Alert history reports
 	@configuration
 	Scenario: Single host alert history
 		Given I visit the alert history page for host "linux-server1"
-		Then I should see "OK - Sven Melander"
-		And I should see "Reporting period: Forever"
+		Then I should see "Reporting period: Today"
+		And I should see "No log data recorded during this time"
 		And I shouldn't see "win-server"
 
 	@configuration
@@ -50,6 +50,7 @@ Feature: Alert history reports
 		Then "Show all" should be unchecked
 		And "objects" should have option "linux-server1"
 		When I uncheck "Up"
+		And select "Forever" from "Reporting period"
 		And I click "Update"
 		Then I shouldn't see "Sven Melander"
 

--- a/features/alert_history.feature
+++ b/features/alert_history.feature
@@ -168,6 +168,7 @@ Feature: Alert history reports
 		| report_type    | objects       |
 		| hosts          | win-server1   |
 		And I enter "1" into "Items to show"
+		And select "Forever" from "Reporting period"
 		And I check "Older entries first"
 		And I click "Update"
 		Then I should see "OK - laa-laa"

--- a/features/step_definitions/nagios.rb
+++ b/features/step_definitions/nagios.rb
@@ -25,6 +25,13 @@ Given /^I have these report data entries:$/ do |table|
   SQLHelpers::insert_sql_data_into_table("merlin", "report_data", table);
 end
 
+Given /^I have these additional report data entries on current timestamp:$/ do |table|
+  table.map_column!('timestamp') { | timestamp |
+    DateTime.now.strftime('%F %T %s') rescue timestamp
+  }
+  SQLHelpers::insert_sql_data_into_table("merlin", "report_data", table);
+end
+
 When /^I have submitted a passive ([a-z]+) check result "(.*)"$/ do |type, check_result|
   if type == 'host' then
     @configuration.add_host_check_result check_result

--- a/modules/reports/libraries/Alert_history_options.php
+++ b/modules/reports/libraries/Alert_history_options.php
@@ -7,7 +7,7 @@ class Alert_history_options extends Summary_options {
 
 	public function setup_properties() {
 		parent::setup_properties();
-		$this->properties['report_period']['default'] = 'forever';
+		$this->properties['report_period']['default'] = 'today';
 		$this->properties['report_type']['default'] = 'hosts';
 		$this->properties['summary_items']['default'] = config::get('pagination.default.items_per_page');
 		$this->properties['objects']['default'] = Report_options::ALL_AUTHORIZED;

--- a/modules/reports/libraries/Alert_history_options.php
+++ b/modules/reports/libraries/Alert_history_options.php
@@ -7,7 +7,7 @@ class Alert_history_options extends Summary_options {
 
 	public function setup_properties() {
 		parent::setup_properties();
-		$this->properties['report_period']['default'] = 'today';
+		$this->properties['report_period']['default'] = 'last24hours';
 		$this->properties['report_type']['default'] = 'hosts';
 		$this->properties['summary_items']['default'] = config::get('pagination.default.items_per_page');
 		$this->properties['objects']['default'] = Report_options::ALL_AUTHORIZED;


### PR DESCRIPTION
This commit provides a workaround for the issue on generating the alert history. Since it is taking much time to load when it is set to 'forever', changed it to 'today' to lessen the amount of data it needs to process and load on the UI.

This resolves MON-13281

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>