### PR TITLE
Bugfix/mon 13281 alert history mon8

### DIFF
--- a/modules/reports/libraries/Alert_history_options.php
+++ b/modules/reports/libraries/Alert_history_options.php
@@ -7,7 +7,7 @@ class Alert_history_options extends Summary_options {
 
 	public function setup_properties() {
 		parent::setup_properties();
-		$this->properties['report_period']['default'] = 'forever';
+		$this->properties['report_period']['default'] = 'today';
 		$this->properties['report_type']['default'] = 'hosts';
 		$this->properties['summary_items']['default'] = config::get('pagination.default.items_per_page');
 		$this->properties['objects']['default'] = Report_options::ALL_AUTHORIZED;


### PR DESCRIPTION
This commit provides a workaround for the issue on generating the alert history. Since it is taking much time to load when it is set to 'forever', changed it to 'today' to lessen the amount of data it needs to process and load on the UI.

This resolves MON-13281

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>