### PR TITLE
Workaround for DST CI failures

### DIFF
--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -3,6 +3,7 @@ post:
      - libyaml
   steps: |
 
+    timedatectl set-timezone Europe/Stockholm
     if [ -f /etc/init.d/httpd ]; then service httpd restart; fi
     if [ -f /etc/init.d/mysqld ]; then service mysqld restart; fi
 


### PR DESCRIPTION
This commit adjusts the timezone of the test VM to Europe/Stockholm in post custom step since adjusting the timezone in PHP does not seem to handle DST.

This is part of MON-13284.