### PR TITLE
Bugfix/mon 13179 moved unit of measure

### DIFF
--- a/modules/monitoring/views/extinfo/components/performance.php
+++ b/modules/monitoring/views/extinfo/components/performance.php
@@ -100,6 +100,7 @@ if(count($perf_data)) {
 			<th><!-- State --></th>
 			<th>Label</th>
 			<th>Value</th>
+			<th>UOM</th>
 			<th>Warning</th>
 			<th>Critical</th>
 			<th>Min</th>
@@ -125,7 +126,12 @@ if(count($perf_data)) {
 			</td>
 			<td>
 <?php
-		echo (isset($ds['value']) ? $ds['value'] . (isset($ds['unit']) ? $ds['unit'] : '') : '');
+		echo (isset($ds['value']) ? $ds['value'] : '');
+?>
+			</td>
+			<td>
+<?php
+		echo (isset($ds['value']) ? (isset($ds['unit']) ? $ds['unit'] : '') : '');
 ?>
 			</td>
 			<td>
@@ -140,12 +146,12 @@ if(count($perf_data)) {
 			</td>
 			<td>
 <?php
-		echo (isset($ds['min']) ? $ds['min'] . (isset($ds['unit']) ? $ds['unit'] : '') : '');
+		echo (isset($ds['min']) ? $ds['min'] : '');
 ?>
 			</td>
 			<td>
 <?php
-		echo (isset($ds['max']) ? $ds['max'] . (isset($ds['unit']) ? $ds['unit'] : '') : '');
+		echo (isset($ds['max']) ? $ds['max'] : '');
 ?>
 			</td>
 		</tr>

--- a/modules/monitoring/views/extinfo/components/performance.php
+++ b/modules/monitoring/views/extinfo/components/performance.php
@@ -125,7 +125,7 @@ if(count($perf_data)) {
 			</td>
 			<td>
 <?php
-		echo (isset($ds['value']) ? $ds['value'] : '') . (isset($ds['unit']) ? $ds['unit'] : '');
+		echo (isset($ds['value']) ? $ds['value'] . (isset($ds['unit']) ? $ds['unit'] : '') : '');
 ?>
 			</td>
 			<td>
@@ -140,12 +140,12 @@ if(count($perf_data)) {
 			</td>
 			<td>
 <?php
-		echo (isset($ds['min']) ? $ds['min'] : '') . (isset($ds['unit']) ? $ds['unit'] : '');
+		echo (isset($ds['min']) ? $ds['min'] . (isset($ds['unit']) ? $ds['unit'] : '') : '');
 ?>
 			</td>
 			<td>
 <?php
-		echo (isset($ds['max']) ? $ds['max'] : '') . (isset($ds['unit']) ? $ds['unit'] : '');
+		echo (isset($ds['max']) ? $ds['max'] . (isset($ds['unit']) ? $ds['unit'] : '') : '');
 ?>
 			</td>
 		</tr>


### PR DESCRIPTION
This added a new column on the performance data table. A column 'UOM' is added beside the value column to identify the unit of measure used for each value. This column is blank when there is no assigned value for the item.

This resolves MON-13179

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>