### PR TITLE
Update filter when modified

### DIFF
--- a/modules/lsfilter/models/lsfilter_saved_queries.php
+++ b/modules/lsfilter/models/lsfilter_saved_queries.php
@@ -129,10 +129,10 @@ class LSFilter_Saved_Queries_Model extends Model {
 
 		// Check if exist
 		if( $user === null ) {
-			$sql_query = "SELECT `id` FROM ".self::tablename." WHERE username IS NULL AND filter_name = %s LIMIT 1";
+			$sql_query = "SELECT `id` FROM ".self::tablename." WHERE username IS NULL AND filter_name = %s";
 			$args = array($name, $metadata['name']);
 		} else {
-			$sql_query = "SELECT `id` FROM ".self::tablename." WHERE username = %s AND filter_name = %s LIMIT 1";
+			$sql_query = "SELECT `id` FROM ".self::tablename." WHERE username = %s AND filter_name = %s";
 			$args = array($user, $name, $metadata['name']);
 		}
 		$sql_query = vsprintf( $sql_query, array_map( array($db, 'escape'), $args ) );

--- a/modules/lsfilter/models/lsfilter_saved_queries.php
+++ b/modules/lsfilter/models/lsfilter_saved_queries.php
@@ -137,19 +137,15 @@ class LSFilter_Saved_Queries_Model extends Model {
 		}
 		$sql_query = vsprintf( $sql_query, array_map( array($db, 'escape'), $args ) );
 		$res = $db->query($sql_query);
+		$id = $res[0]->id;
 
 		// Insert if not exist
 		if (count($res) === 0) {
 			$sql_query = "INSERT INTO ".self::tablename." (username, filter_name, filter_table, filter, filter_description) VALUES (%s,%s,%s,%s,%s)";
 			$args = array($user, $name, $metadata['name'], $query, $name);
 		} else {
-			if( $user === null ) {
-				$sql_query = "UPDATE ".self::tablename." SET filter_table = %s, filter = %s, filter_description = %s WHERE filter_name = %s AND username IS NULL";
-				$args = array($metadata['name'], $query, $name, $name);
-			} else {
-				$sql_query = "UPDATE ".self::tablename." SET filter_table = %s, filter = %s, filter_description = %s WHERE filter_name = %s AND username = %s";
-				$args = array($metadata['name'], $query, $name, $name, $user);
-			}
+			$sql_query = "UPDATE ".self::tablename." SET filter_table = %s, filter = %s, filter_description = %s WHERE id = %s";
+			$args = array($metadata['name'], $query, $name, $id);
 		}
 		$sql_query = vsprintf( $sql_query, array_map( array($db, 'escape'), $args ) );
 		$db->query($sql_query);

--- a/modules/lsfilter/models/lsfilter_saved_queries.php
+++ b/modules/lsfilter/models/lsfilter_saved_queries.php
@@ -129,10 +129,10 @@ class LSFilter_Saved_Queries_Model extends Model {
 
 		// Check if exist
 		if( $user === null ) {
-			$sql_query = "SELECT `id` FROM ".self::tablename." WHERE username IS NULL AND filter_name = %s";
+			$sql_query = "SELECT `id` FROM ".self::tablename." WHERE username IS NULL AND filter_name = %s LIMIT 1";
 			$args = array($name, $metadata['name']);
 		} else {
-			$sql_query = "SELECT `id` FROM ".self::tablename." WHERE username = %s AND filter_name = %s";
+			$sql_query = "SELECT `id` FROM ".self::tablename." WHERE username = %s AND filter_name = %s LIMIT 1";
 			$args = array($user, $name, $metadata['name']);
 		}
 		$sql_query = vsprintf( $sql_query, array_map( array($db, 'escape'), $args ) );

--- a/modules/lsfilter/models/lsfilter_saved_queries.php
+++ b/modules/lsfilter/models/lsfilter_saved_queries.php
@@ -137,13 +137,13 @@ class LSFilter_Saved_Queries_Model extends Model {
 		}
 		$sql_query = vsprintf( $sql_query, array_map( array($db, 'escape'), $args ) );
 		$res = $db->query($sql_query);
-		$id = $res[0]->id;
 
 		// Insert if not exist
 		if (count($res) === 0) {
 			$sql_query = "INSERT INTO ".self::tablename." (username, filter_name, filter_table, filter, filter_description) VALUES (%s,%s,%s,%s,%s)";
 			$args = array($user, $name, $metadata['name'], $query, $name);
 		} else {
+			$id = $res[0]->id;
 			$sql_query = "UPDATE ".self::tablename." SET filter_table = %s, filter = %s, filter_description = %s WHERE id = %s";
 			$args = array($metadata['name'], $query, $name, $id);
 		}


### PR DESCRIPTION
This commit checks if there is an existing filter name under the same username then update it instead of deleting and re-inserting the filter details. Global filters were saved will a NULL username. Global filters can have the same name as local filters. Saving a filter with the same name and scope but with different filter_table will only update the filter query.

This resolves MON-13298

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>