### PR TITLE
Added a default comment if empty

### DIFF
--- a/modules/monitoring/models/host.php
+++ b/modules/monitoring/models/host.php
@@ -549,6 +549,10 @@ class Host_Model extends BaseHost_Model {
 	 * @ninja orm_command view monitoring/naemon_command
 	 */
 	public function schedule_downtime($start_time, $end_time, $flexible, $duration, $trigger_id, $propagation, $comment) {
+		if(empty(trim($comment))) {
+			$comment = "Scheduled by ".$this->get_current_user();
+		}
+		
 		$duration_sec = intval(floatval($duration) * 3600);
 
 		$trigger_id = intval($trigger_id);

--- a/modules/monitoring/models/service.php
+++ b/modules/monitoring/models/service.php
@@ -566,6 +566,10 @@ class Service_Model extends BaseService_Model {
 	 * @return array ['status' => boolean, 'output' => string]
 	 */
 	public function schedule_downtime($start_time, $end_time, $flexible, $duration, $trigger_id, $comment) {
+		if(empty(trim($comment))) {
+			$comment = "Scheduled by ".$this->get_current_user();
+		}
+		
 		$duration_sec = intval(floatval($duration) * 3600);
 
 		$trigger_id = intval($trigger_id);


### PR DESCRIPTION
Comment field is not required when creating a downtime schedule. This commit adds a default value when comment field is empty and there is no default comment configured by the user.

This resolves MON-13301

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>