### PR TITLE
Sets a default sort value for comments

### DIFF
--- a/modules/lsfilter/controllers/listview.php
+++ b/modules/lsfilter/controllers/listview.php
@@ -79,6 +79,10 @@ EOF;
 		$columns = $this->input->get('columns',$this->input->post('columns',false));
 		$sort = $this->input->get('sort',$this->input->post('sort',array()));
 
+		if(strpos($query, "[comments]") !== false && count($sort)==0){
+			$sort = array("entry_time desc");
+		} 
+
 		$limit = $this->input->get('limit',$this->input->post('limit',false));
 		$offset = $this->input->get('offset',$this->input->post('offset',false));
 


### PR DESCRIPTION
A default value is set for sort variable when the query is intended for comments table. This value will only be used on initial load of the page and if the user has not selected a sorting order yet.

This should not affect other extinfo page tables that are not related to comments.

This resolves MON-10404.

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>