### PR TITLE
Updated displayed error for lmd and naemon

### DIFF
--- a/application/views/template.php
+++ b/application/views/template.php
@@ -52,7 +52,9 @@
 							// Check Livestatus.
 							exec('service naemon status', $output, $return_var_le);
 
-							if($return_var_lmd !== 0 && $return_var_le === 0){
+							if($return_var_lmd !== 0 && $return_var_le !== 0){
+								$services_down = "The OP5 Monitor services LMD and Naemon are not running, please";
+							} elseif($return_var_lmd !== 0 && $return_var_le === 0){
 								$service_down = "The OP5 Monitor service LMD is not running, please";
 							} elseif($return_var_lmd === 0 && $return_var_le !== 0) {
 								$service_down = "The OP5 Monitor service Naemon is not running, please";

--- a/application/views/template.php
+++ b/application/views/template.php
@@ -53,14 +53,14 @@
 							exec('service naemon status', $output, $return_var_le);
 
 							if($return_var_lmd !== 0 && $return_var_le === 0){
-								$services_down = 'The OP5 Monitor service LMD is not running, please contact your administrator.';
-							} elseif($return_var_lmd !== 0 && $return_var_le !== 0) {
-								$services_down = 'Issues encountered, check LMD and Naemon Logs for details.';
+								$service_down = "The OP5 Monitor service LMD is not running, please";
+							} elseif($return_var_lmd === 0 && $return_var_le !== 0) {
+								$service_down = "The OP5 Monitor service Naemon is not running, please";
 							} else {
-								$services_down = 'The OP5 Monitor services LMD and Naemon are not running, please contact your administrator.';
+								$services_down = 'Issues encountered, check LMD and Naemon Logs for details or';
 							}
 							echo '<div class=" info-notice info-notice-error info-notice-service-error">';
-								echo $services_down;
+								echo $services_down." contact your administrator.";
 							echo '</div>';
 						}
 					?>

--- a/application/views/template.php
+++ b/application/views/template.php
@@ -45,7 +45,7 @@
 								echo $content;
 							}
 						} else {
-							$services_down = 'services LMD and Naemon are not running';
+							$services_down = '';
 
 							// Check LMD.
 							exec('service lmd status', $output, $return_var_lmd);
@@ -53,10 +53,14 @@
 							exec('service naemon status', $output, $return_var_le);
 
 							if($return_var_lmd !== 0 && $return_var_le === 0){
-								$services_down = 'service LMD is not running';
+								$services_down = 'The OP5 Monitor service LMD is not running, please contact your administrator.';
+							} elseif($return_var_lmd !== 0 && $return_var_le !== 0) {
+								$services_down = 'Issues encountered, check LMD and Naemon Logs for details.';
+							} else {
+								$services_down = 'The OP5 Monitor services LMD and Naemon are not running, please contact your administrator.';
 							}
 							echo '<div class=" info-notice info-notice-error info-notice-service-error">';
-								echo 'The OP5 Monitor '.$services_down.', please contact your administrator.';
+								echo $services_down;
 							echo '</div>';
 						}
 					?>


### PR DESCRIPTION
This commit added a condition for handling lmd and naemon service status. Currently, the template only displays an error pointing that both lmd and naemon's not running.

This resolves MON-13199.

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>