### PR TITLE
Fix Issue in backup tests

### DIFF
--- a/test/backup_Test.php
+++ b/test/backup_Test.php
@@ -17,7 +17,7 @@ class Backup_Test extends \PHPUnit\Framework\TestCase {
 			return;
 		}
 
-		$this->backup_location =  __DIR__.'/a_temp_dir_heyo';
+		$this->backup_location =  './a_temp_dir_heyo';
 		exec("mkdir $this->backup_location", $output, $exit_code);
 		if($exit_code != 0) {
 			$this->markTestSkipped("Could not create a temporary ".


### PR DESCRIPTION
tarfile extraction via python is no longer allowed to use absolute paths. The test was updated to use local directory for backup location.

This resolves MON-13339.