### PR TITLE
Sets initial value on Event Log to 7 days

### DIFF
--- a/modules/monitoring/controllers/showlog.php
+++ b/modules/monitoring/controllers/showlog.php
@@ -64,6 +64,8 @@ class Showlog_Controller extends Ninja_Controller
 		if (!$this->mayi->run('monitoring.status:read.showlog')) {
 			$this->options['hide_process'] = 1;
 			$this->options['hide_commands'] = 1;
+			//sets an initial value on First Time Calendar Date
+			$this->options['first'] = date(strtotime("-1 week"));
 		}
 	}
 


### PR DESCRIPTION
This commit sets an initial value to First Time Calendar Date as 7 days. This also removes the limit value of 2500 on initial load but will still be used if First and Last time Calendar was empty.

This resolves MON-13368

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>