### PR TITLE
Removed show logs from all nodes checkbox

### DIFF
--- a/modules/monitoring/helpers/showlog.php
+++ b/modules/monitoring/helpers/showlog.php
@@ -89,10 +89,6 @@ class showlog
 			$args[] = '--reverse';
 		}
 
-		if (!empty($options['all_nodes'])) {
-			$args[] = '--all-nodes';
-		}
-
 		# invoke a hard limit in case the user didn't set any.
 		# This will prevent php from exiting with an out-of-memory
 		# error, and will also stop users' browsers from hanging

--- a/modules/monitoring/views/showlog/showlog.php
+++ b/modules/monitoring/views/showlog/showlog.php
@@ -14,7 +14,6 @@
 			<label><?php echo form::checkbox('hide_logrotation', 1, isset($options['hide_logrotation'])).' '._('Hide logrotation messages'); ?></label><br />
 			<?php echo $is_authorized ? '<label>'.form::checkbox('hide_commands', 1, isset($options['hide_commands'])).' '._('Hide external commands').'</label><br />' : ''; ?>
 			<label><?php echo form::checkbox('parse_forward', 1, isset($options['parse_forward'])).' '._('Older entries first'); ?></label><br />
-			<label><?php echo form::checkbox('all_nodes', 1, isset($options['all_nodes'])).' '._('Show logs from all nodes'); ?></label><br />
 			</td>
 			<td class="showlog_options">
 				<table>


### PR DESCRIPTION
This commit removes the show all logs from nodes checkbox on the gui. The show logs from all nodes function should still work via cmd line.

This resolves MON-13363.

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>