### PR TITLE
Alternative library to replace wkhtmltopdf

### DIFF
--- a/modules/reports/controllers/base_reports.php
+++ b/modules/reports/controllers/base_reports.php
@@ -83,7 +83,7 @@ abstract class Base_reports_Controller extends Ninja_Controller
 	 *
 	 * Assumes that $this->template is set up correctly
 	 */
-	protected function generate_pdf()
+	public function generate_pdf()
 	{
 		//  Require tcpdf
 		require Kohana::find_file('vendor', 'tcpdf/tcpdf');

--- a/modules/reports/controllers/base_reports.php
+++ b/modules/reports/controllers/base_reports.php
@@ -51,7 +51,7 @@ abstract class Base_reports_Controller extends Ninja_Controller
 		$this->template->toolbar = new Toolbar_Controller('Report');
 
 		if($this->type != 'histogram') {
-			$pdf_button = form::open($this->type.'/generate');
+			$pdf_button = form::open($this->type.'/generate', array('target'=>'_blank'));
 			$pdf_button .= $this->options->as_form();
 			$pdf_button .= '<input type="hidden" name="output_format" value="pdf" />';
 			$pdf_button .= sprintf('<input type="submit" value="%s" />', _('As PDF'));

--- a/modules/reports/controllers/base_reports.php
+++ b/modules/reports/controllers/base_reports.php
@@ -51,8 +51,7 @@ abstract class Base_reports_Controller extends Ninja_Controller
 		$this->template->toolbar = new Toolbar_Controller('Report');
 
 		if($this->type != 'histogram') {
-			$pdf_button = form::open($this->type.'/generate', array('target'=>'_blank')
-		);
+			$pdf_button = form::open($this->type.'/generate', array('target'=>'_blank'));
 			$pdf_button = '<input type="hidden" name="output_format" value="pdf" />';
 			$pdf_button .= sprintf('<input type="submit" value="%s" id="generate_pdf_file"/>', _('As PDF'));
 			$this->template->toolbar->html_as_button($pdf_button);

--- a/modules/reports/controllers/base_reports.php
+++ b/modules/reports/controllers/base_reports.php
@@ -107,8 +107,7 @@ abstract class Base_reports_Controller extends Ninja_Controller
 		// GET contents from _POST
 		if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 			if (isset($_POST['content'])) {
-				// Retrieve the HTML content sent from JavaScript
-				$content = $_POST['htmlContent'];
+				$content = $_POST['content'];
 				$this->log->log('debug', "HTML: $content");
 			} else {
 				$this->log->log('debug', "Error: 'htmlContent' key not found in POST data");

--- a/modules/reports/controllers/base_reports.php
+++ b/modules/reports/controllers/base_reports.php
@@ -53,10 +53,8 @@ abstract class Base_reports_Controller extends Ninja_Controller
 		if($this->type != 'histogram') {
 			$pdf_button = form::open($this->type.'/generate', array('target'=>'_blank')
 		);
-			$pdf_button .= $this->options->as_form();
-			$pdf_button .= '<input type="hidden" name="output_format" value="pdf" />';
-			$pdf_button .= sprintf('<input type="submit" value="%s" />', _('As PDF'));
-			$pdf_button .= '</form>';
+			$pdf_button = '<input type="hidden" name="output_format" value="pdf" />';
+			$pdf_button .= sprintf('<input type="submit" value="%s" id="generate_pdf_file"/>', _('As PDF'));
 			$this->template->toolbar->html_as_button($pdf_button);
 
 			$csv_button = form::open($this->type.'/generate');
@@ -160,8 +158,6 @@ abstract class Base_reports_Controller extends Ninja_Controller
 		//============================================================+
 		// END OF FILE
 		//============================================================+
-
-		// Create logs - Ongoing
 	}
 
 	/**

--- a/modules/reports/controllers/base_reports.php
+++ b/modules/reports/controllers/base_reports.php
@@ -112,12 +112,12 @@ abstract class Base_reports_Controller extends Ninja_Controller
 			if (isset($_POST['content'])) {
 				// Retrieve the HTML content sent from JavaScript
 				$content = $_POST['htmlContent'];
+				$this->log->log('debug', "HTML: $content");
 			} else {
-				// 'content' key is not set in the POST data
-				echo "Error: 'content' key not found in POST data";
+				$this->log->log('debug', "Error: 'htmlContent' key not found in POST data");
 			}
 		} else {
-			echo "Error!";
+			$this->log->log('debug', "Error: No POST data found");
 		}
 
 		//prepare css file - Ongoing : Still looking for styles for tables and graphs

--- a/modules/reports/src/js/common.js
+++ b/modules/reports/src/js/common.js
@@ -444,3 +444,36 @@ function filter_mapping_mapping()
 	if (!$(this).siblings('.configure_mapping').find('.filter_map:visible').length)
 		$(this).siblings('.configure_mapping').hide();
 }
+
+function run_generation_pdf()
+{
+	var htmlString = document.getElementById('report-page').innerHTML;
+
+	var parser = new DOMParser();
+	var doc = parser.parseFromString(htmlString, 'text/html');
+	// remove div that contains links
+	var divToRemove = doc.getElementById('report-links-internal');
+	if (divToRemove) {
+		divToRemove.parentNode.removeChild(divToRemove);
+	}
+	var source = doc.documentElement.innerHTML;
+
+	$.ajax({
+		url: _site_domain + _index_page + '/' + _controller_name + '/generatepdf',
+		type: 'post',
+		data: {content:source},
+		success: function(response) {
+			console.log('Request Successful! :', response);
+		},
+		error: function(xhr, status, error) {
+			var msg;
+			if (xhr.status === 403) {
+				msg ='You do not have permission to access this resource.';
+			} else {
+				msg ='An error occurred. '+error;
+			}
+			$.notify("Failed to generate report: " + msg, {'sticky': true});
+		},
+		dataType: 'json'
+	});
+}

--- a/modules/reports/src/js/reports.js
+++ b/modules/reports/src/js/reports.js
@@ -97,33 +97,6 @@ $(document).ready(function() {
 
 });
 
-function run_generation_pdf()
-{
-	var htmlString = document.getElementById('report-page').innerHTML;
-
-	var parser = new DOMParser();
-	var doc = parser.parseFromString(htmlString, 'text/html');
-	// remove div that contains links
-	var divToRemove = doc.getElementById('report-links-internal');
-	if (divToRemove) {
-		divToRemove.parentNode.removeChild(divToRemove);
-	}
-	var source = doc.documentElement.innerHTML;
-
-	$.ajax({
-		url: _site_domain + _index_page + '/base_reports/generate_pdf/',
-		type: 'post',
-		data: {content:source},
-		success: function(response) {
-			console.log('Response from PHP Controller:', response);
-		},
-		error: function(xhr, status, error) {
-			console.error('Error: ', error+' Status: '+status);
-		},
-		dataType: 'json'
-	});
-}
-
 // Propagate sla values
 function set_report_form_values(the_val)
 {

--- a/modules/reports/src/js/reports.js
+++ b/modules/reports/src/js/reports.js
@@ -92,7 +92,37 @@ $(document).ready(function() {
 			dataType: 'json'
 		});
 	});
+
+	$("#generate_pdf_file").click(run_generation_pdf);
+
 });
+
+function run_generation_pdf()
+{
+	var htmlString = document.getElementById('report-page').innerHTML;
+
+	var parser = new DOMParser();
+	var doc = parser.parseFromString(htmlString, 'text/html');
+	// remove div that contains links
+	var divToRemove = doc.getElementById('report-links-internal');
+	if (divToRemove) {
+		divToRemove.parentNode.removeChild(divToRemove);
+	}
+	var source = doc.documentElement.innerHTML;
+
+	$.ajax({
+		url: _site_domain + _index_page + '/base_reports/generate_pdf/',
+		type: 'post',
+		data: {content:source},
+		success: function(response) {
+			console.log('Response from PHP Controller:', response);
+		},
+		error: function(xhr, status, error) {
+			console.error('Error: ', error+' Status: '+status);
+		},
+		dataType: 'json'
+	});
+}
 
 // Propagate sla values
 function set_report_form_values(the_val)

--- a/modules/reports/views/reports/index.php
+++ b/modules/reports/views/reports/index.php
@@ -54,33 +54,3 @@
 	}
 ?>
 </div>
-<script>
-	// this will capture rendered output as html strings
-	function captureReport() {
-		var htmlContent = document.getElementById('report-page').innerHTML;
-		// working on captured html string will match the displayed data to the pdf to be generated
-		// and this will also remove the use of javascripts that will avoid missing components on the pdf
-		console.log(htmlContent);
-
-		// using ajax to submit client-side variables to the controller
-		var xhr = new XMLHttpRequest();
-		<?php 
-			$reportcontroller = Kohana::find_file('controllers','base_reports');
-			// ninja/modules/reports/controllers/base_reports.php
-		?>
-		xhr.open('POST', '<?php echo json_encode($reportcontroller);?>', true); // checking if this needs an update
-		xhr.setRequestHeader('Content-Type', 'application/json');
-		xhr.onreadystatechange = function() {
-			if (xhr.status == 200) {
-				console.log('Submit successful');
-			} else {
-				console.log('Status:'+xhr.status); // currently results to 403 (FORBIDDEN)
-			}
-		}; 
-		xhr.send('htmlContent=' + encodeURIComponent(htmlContent));
-	}
-
-	$(window).on("load", function () {
-		captureReport();
-	});
-</script>

--- a/modules/reports/views/reports/index.php
+++ b/modules/reports/views/reports/index.php
@@ -1,5 +1,5 @@
 <?php defined('SYSPATH') OR die('No direct access allowed.'); ?>
-<div class="report-page">
+<div id="report-page" name="report-page" class="report-page">
 <?php
 	echo isset($error) ? $error : '';
 	if ($header instanceof View) {

--- a/modules/reports/views/reports/index.php
+++ b/modules/reports/views/reports/index.php
@@ -54,3 +54,33 @@
 	}
 ?>
 </div>
+<script>
+	// this will capture rendered output as html strings
+	function captureReport() {
+		var htmlContent = document.getElementById('report-page').innerHTML;
+		// working on captured html string will match the displayed data to the pdf to be generated
+		// and this will also remove the use of javascripts that will avoid missing components on the pdf
+		console.log(htmlContent);
+
+		// using ajax to submit client-side variables to the controller
+		var xhr = new XMLHttpRequest();
+		<?php 
+			$reportcontroller = Kohana::find_file('controllers','base_reports');
+			// ninja/modules/reports/controllers/base_reports.php
+		?>
+		xhr.open('POST', '<?php echo json_encode($reportcontroller);?>', true); // checking if this needs an update
+		xhr.setRequestHeader('Content-Type', 'application/json');
+		xhr.onreadystatechange = function() {
+			if (xhr.status == 200) {
+				console.log('Submit successful');
+			} else {
+				console.log('Status:'+xhr.status); // currently results to 403 (FORBIDDEN)
+			}
+		}; 
+		xhr.send('htmlContent=' + encodeURIComponent(htmlContent));
+	}
+
+	$(window).on("load", function () {
+		captureReport();
+	});
+</script>


### PR DESCRIPTION
This uses tcpdf as an alternative to wkhtmltopdf library. It uses a new tab when saving a pdf to give a preview of the pdf to use.
Still working on to most css styles configurations needed to provide the same browser output.

This is part of MON-13267

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>