### PR TITLE
Fix incomplete display of host and service page when host is down

### DIFF
--- a/modules/monitoring/views/extinfo/components/performance.php
+++ b/modules/monitoring/views/extinfo/components/performance.php
@@ -52,7 +52,7 @@ if(count($perf_data)) {
 				var chart = c3.generate({
 					bindto: "#<?php echo $id; ?>",
 					data: {
-						columns: [['<?php echo $ds_name; ?>', <?php echo $ds['value']; ?>]],
+						columns: [['<?php echo $ds_name; ?>', <?php echo "" . (isset($ds['value']))? $ds['value']: 0; ?>]],
 						type: "gauge"
 					},
 					gauge: {


### PR DESCRIPTION
Fix incomplete display of host and service page
when host is down to comprehend change of
check_icmp output from monitoring-plugins
v2.3.5 and up.

Part of MON-13431.

Signed-off-by: Jerick Macario <jmacario@itrsgroup.com>