### PR TITLE
Enhance XSS protection in cmd and exec view

### DIFF
--- a/modules/lsfilter/controllers/cmd.php
+++ b/modules/lsfilter/controllers/cmd.php
@@ -39,7 +39,7 @@ class Cmd_Controller extends Ninja_Controller {
 
 		if (count($set) === 0) {
 			$this->template->content->error_level = 'info';
-			$this->template->content->error = "The " . $pool->get_table() . " you were trying to execute '" . html::specialchars($command, ENT_QUOTES, 'UTF-8') . "' on were not found. Attempted to find " . $pool->get_table() . " with the names: " . html::get_delimited_string(html::specialchars($object_keys, ENT_QUOTES, 'UTF-8'));
+			$this->template->content->error = "The " . $pool->get_table() . " you were trying to execute '" . htmlspecialchars($command, ENT_QUOTES, 'UTF-8') . "' on were not found. Attempted to find " . $pool->get_table() . " with the names: " . html::get_delimited_string($object_keys);
 
 			return;
 		}

--- a/modules/lsfilter/controllers/cmd.php
+++ b/modules/lsfilter/controllers/cmd.php
@@ -39,7 +39,7 @@ class Cmd_Controller extends Ninja_Controller {
 
 		if (count($set) === 0) {
 			$this->template->content->error_level = 'info';
-			$this->template->content->error = "The " . $pool->get_table() . " you were trying to execute '" . $command . "' on were not found. Attempted to find " . $pool->get_table() . " with the names: " . html::get_delimited_string($object_keys);
+			$this->template->content->error = "The " . $pool->get_table() . " you were trying to execute '" . html::specialchars($command, ENT_QUOTES, 'UTF-8') . "' on were not found. Attempted to find " . $pool->get_table() . " with the names: " . html::get_delimited_string(html::specialchars($object_keys, ENT_QUOTES, 'UTF-8'));
 
 			return;
 		}
@@ -96,7 +96,8 @@ class Cmd_Controller extends Ninja_Controller {
 				"'$table'. Please verify your user's rights ".
 				"for '$table' commands. Aborting without any ".
 				"commands applied.";
-			op5log::instance('ninja')->log('warning', $error_message);
+			op5log::instance('ninja')->log('warning',
+				htmlspecialchars($error_message, ENT_QUOTES, 'UTF-8'));
 			$this->template->content->error = $error_message;
 			$this->template->content->error_level = 'notice';
 			return;
@@ -175,7 +176,13 @@ class Cmd_Controller extends Ninja_Controller {
 					if(isset($result['output'])) {
 						$output = " Output: ".$result['output'];
 					}
-					op5log::instance('ninja')->log('warning', "Failed to submit command '$command' on (".$object->get_table().") object '".$object->get_key()."'".$output);
+					$log_msg = "Failed to submit command '"
+						.htmlspecialchars($command, ENT_QUOTES, 'UTF-8')."' on ("
+						.htmlspecialchars($object->get_table(), ENT_QUOTES, 'UTF-8')
+						.") object '"
+						.htmlspecialchars($object->get_key(), ENT_QUOTES, 'UTF-8')
+						."'".$output;
+					op5log::instance('ninja')->log('warning', $log_msg);
 				}
 
 				$results[] = array(
@@ -243,7 +250,13 @@ class Cmd_Controller extends Ninja_Controller {
 					if(isset($result['output'])) {
 						$output = " Output: ".$result['output'];
 					}
-					op5log::instance('ninja')->log('warning', "Failed to submit command '$command' on (".$object->get_table().") object '".$object->get_key()."'".$output);
+					$log_msg = "Failed to submit command '"
+						.htmlspecialchars($command, ENT_QUOTES, 'UTF-8')."' on ("
+						.htmlspecialchars($object->get_table(), ENT_QUOTES, 'UTF-8')
+						.") object '"
+						.htmlspecialchars($object->get_key(), ENT_QUOTES, 'UTF-8')
+						."'".$output;
+					op5log::instance('ninja')->log('warning', $log_msg);
 				}
 				$command_template->result = $result;
 				$command_template->object = $object;
@@ -255,11 +268,14 @@ class Cmd_Controller extends Ninja_Controller {
 		} catch(ORMException $e) {
 			request::send_header(400);
 			$error_message = $e->getMessage();
-			op5log::instance('ninja')->log('warning', $error_message);
+			op5log::instance('ninja')->log('warning',
+				htmlspecialchars($error_message, ENT_QUOTES, 'UTF-8'));
 			if(request::is_ajax()) {
 				$this->template = new View('json');
 				$this->template->success = false;
-				$this->template->value = array('error' => $error_message);
+				$this->template->value = array(
+					'error' => htmlspecialchars($error_message, ENT_QUOTES, 'UTF-8'),
+				);
 				return;
 			}
 			$template->result = false;

--- a/modules/lsfilter/views/cmd/exec.php
+++ b/modules/lsfilter/views/cmd/exec.php
@@ -2,7 +2,7 @@
 if(isset($error)) {
 	echo '<div class="alert error">'.sprintf(_('There was an error submitting your command to %s.'), Kohana::config('config.product_name'));
 	if (!empty($error)) {
-		echo '<br /><br />'._('ERROR').': '.$error;
+		echo '<br /><br />'._('ERROR').': '.html::specialchars($error);
 	}
 	echo "</div>\n";
 }


### PR DESCRIPTION
Updated Cmd_Controller to use htmlspecialchars for logging and error messages, ensuring user-generated content is properly escaped to prevent XSS vulnerabilities. Additionally, modified the exec view to apply htmlspecialchars to error output, enhancing security.

This is part of ongoing efforts to improve application security. 
This resolves MON-13745.

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>