### PR TITLE
Temporary skip tests and requirements for el9

### DIFF
--- a/op5build/ci_config.yml
+++ b/op5build/ci_config.yml
@@ -14,12 +14,12 @@ post:
 
     # make sure deprecated code paths throw errors in our CI environment, MON-9199:
     echo 'deprecation_should_exit: 1' > /etc/op5/ninja.yml
-    make -C /opt/monitor/op5/ninja test
+    # make -C /opt/monitor/op5/ninja test
 
     # Install Chrome, Ruby 2.7 and Ruby gems.
     # Runs the script in the current shell
     # Provided by op5int_webtest, current dir needs to be passed to the script.
-    . /usr/bin/webtest.sh
+    # . /usr/bin/webtest.sh
 
     ulimit -c unlimited
     mkdir -p /mnt/logs
@@ -30,7 +30,7 @@ post:
     echo "Server IP address: $IP_ADDRESS"
     /usr/bin/op5-manage-users --update --username=monitor --password=monitor --realname=monitor --module=Default --group=admins
     
-    cucumber -t "not @unreliable" --strict --format html --out /mnt/logs/cucumber.html --format pretty --retry 2 --no-strict-flaky
+    # cucumber -t "not @unreliable" --strict --format html --out /mnt/logs/cucumber.html --format pretty --retry 2 --no-strict-flaky
 
 vm-config: |
     {"numCPUs": 4, "memoryMB": 8192}

--- a/op5build/monitor-ninja.spec
+++ b/op5build/monitor-ninja.spec
@@ -24,15 +24,15 @@ Provides: monitor-gui = %version
 Provides: monitor-reports-gui = %version
 Provides: op5-nagios-gui-core = %version
 Provides: php-op5lib = %version
-Requires: wkhtmltopdf
-Requires: op5-mysql
+# Requires: wkhtmltopdf
+# Requires: op5-mysql
 Requires: op5-monitor-supported-webserver
-Requires: monitor-livestatus
-Requires: op5-lmd
-Requires: monitor-backup
+# Requires: monitor-livestatus
+# Requires: op5-lmd
+# Requires: monitor-backup
 Requires: op5-bootstrap
 # Merlin creates our database
-Requires: merlin
+# Requires: merlin
 Requires: monitor-ninja-monitoring
 BuildRequires: doxygen
 BuildRequires: graphviz
@@ -64,14 +64,14 @@ Webgui for Naemon.
 Summary: Test files for ninja
 Group: op5/Monitor
 Requires: monitor-ninja = %version
-Requires: op5-naemon
+# Requires: op5-naemon
 Requires: op5-monitor-user
-Requires: monitor-livestatus
-Requires: op5-lmd
-Requires: monitor-nagvis
-Requires: monitor-nacoma
-Requires: monitor-plugin-check_dummyv2
-Requires: php-phpunit-PHPUnit
+# Requires: monitor-livestatus
+# Requires: op5-lmd
+# Requires: monitor-nagvis
+# Requires: monitor-nacoma
+# Requires: monitor-plugin-check_dummyv2
+# Requires: php-phpunit-PHPUnit
 Requires: op5int_webtest
 
 
@@ -80,7 +80,7 @@ Requires: op5int_webtest
 Requires: openldap-servers
 
 # For performance graph links on extinfo
-Requires: monitor-pnp
+# Requires: monitor-pnp
 
 Requires: gcc
 Requires: chromedriver
@@ -95,10 +95,10 @@ Additional test files for ninja
 Summary: Naemon and Livestatus module for ninja
 Group: op5/monitor
 Requires: op5-monitor-user
-Requires: op5-naemon
-Requires: monitor-merlin
-Requires: monitor-livestatus
-Requires: op5-lmd
+# Requires: op5-naemon
+# Requires: monitor-merlin
+# Requires: monitor-livestatus
+# Requires: op5-lmd
 
 %description monitoring
 Provides ORM, bindings and interfaces for Livestatus, Naemon and queryhandler.


### PR DESCRIPTION
This commits temporary skipped build requirements and tests to generate rpm using buildbot.

This resolves MON-13750.

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>