### PR TITLE
Fix delete steps on nightly builds

### DIFF
--- a/features/availability.feature
+++ b/features/availability.feature
@@ -480,8 +480,7 @@ Feature: Availability reports
 		Then I should see "Saved reports"
 		And "Saved reports" should have option "saved test report"
 		When I select "saved test report"
-		Then "objects" should have option "LinuxServers"
-		When I click "Delete" and confirm popup
+		And I click "Delete" and confirm popup
 		# Test available first, to force capybara to wait for page reload
 		Then "objects_tmp" should have option "LinuxServers"
 		And "Saved reports" shouldn't have option "saved test report"

--- a/features/histogram.feature
+++ b/features/histogram.feature
@@ -331,8 +331,7 @@ Feature: Histogram reports
 		Then I should see "Saved reports"
 		And "Saved reports" should have option "saved test report"
 		When I select "saved test report"
-		Then "objects" should have option "LinuxServers"
-		When I click "Delete" and confirm popup
+		And I click "Delete" and confirm popup
 		# Test available first, to force capybara to wait for page reload
 		Then "objects_tmp" should have option "LinuxServers"
 		And "Saved reports" shouldn't have option "saved test report"

--- a/features/schedule.feature
+++ b/features/schedule.feature
@@ -96,8 +96,7 @@ Feature: Scheduled reports
 		Then I should see "Saved reports"
 		And "Saved reports" should have option "saved test report"
 		When I select "saved test report"
-		Then "objects" should have option "monitor"
-		When I click "Delete" and confirm popup
+		And I click "Delete" and confirm popup
 		# Test available first, to force capybara to wait for page reload
 		Then "objects_tmp" should have option "monitor"
 		And "Saved reports" shouldn't have option "saved test report"

--- a/features/schedule.feature
+++ b/features/schedule.feature
@@ -95,7 +95,7 @@ Feature: Scheduled reports
 		And I click "Create Availability Report"
 		Then I should see "Saved reports"
 		And "Saved reports" should have option "saved test report"
-		When I select "saved test report" from "Saved reports"
+		When I select "saved test report"
 		Then "objects" should have option "monitor"
 		When I click "Delete" and confirm popup
 		# Test available first, to force capybara to wait for page reload

--- a/features/schedule.feature
+++ b/features/schedule.feature
@@ -96,13 +96,11 @@ Feature: Scheduled reports
 		Then I should see "Saved reports"
 		And "Saved reports" should have option "saved test report"
 		When I select "saved test report"
-		And I wait for 10 seconds
 		Then "objects" should have option "monitor"
 		When I click "Delete" and confirm popup
 		# Test available first, to force capybara to wait for page reload
 		Then "objects_tmp" should have option "monitor"
 		And "Saved reports" shouldn't have option "saved test report"
-		And I wait for 10 seconds
 		And "objects" shouldn't have option "monitor"
 
 	@editedhappypath
@@ -110,7 +108,6 @@ Feature: Scheduled reports
 		When I hover over the "Report" menu
 		And I click "Schedule reports"
 		Then I should see "New Schedule"
-		And I wait for 10 seconds
 		And I shouldn't see "saved_test_report"
 		And I shouldn't see "saved test report"
 		And "Select report" shouldn't have option "saved test report"

--- a/features/schedule.feature
+++ b/features/schedule.feature
@@ -95,7 +95,7 @@ Feature: Scheduled reports
 		And I click "Create Availability Report"
 		Then I should see "Saved reports"
 		And "Saved reports" should have option "saved test report"
-		When I select "saved test report"
+		When I select "saved test report" from "Saved reports"
 		Then "objects" should have option "monitor"
 		When I click "Delete" and confirm popup
 		# Test available first, to force capybara to wait for page reload

--- a/features/schedule.feature
+++ b/features/schedule.feature
@@ -96,11 +96,13 @@ Feature: Scheduled reports
 		Then I should see "Saved reports"
 		And "Saved reports" should have option "saved test report"
 		When I select "saved test report"
+		And I wait for 10 seconds
 		Then "objects" should have option "monitor"
 		When I click "Delete" and confirm popup
 		# Test available first, to force capybara to wait for page reload
 		Then "objects_tmp" should have option "monitor"
 		And "Saved reports" shouldn't have option "saved test report"
+		And I wait for 10 seconds
 		And "objects" shouldn't have option "monitor"
 
 	@editedhappypath
@@ -108,6 +110,7 @@ Feature: Scheduled reports
 		When I hover over the "Report" menu
 		And I click "Schedule reports"
 		Then I should see "New Schedule"
+		And I wait for 10 seconds
 		And I shouldn't see "saved_test_report"
 		And I shouldn't see "saved test report"
 		And "Select report" shouldn't have option "saved test report"

--- a/features/sla.feature
+++ b/features/sla.feature
@@ -527,8 +527,7 @@ Feature: SLA reports
 		Then I should see "Saved reports"
 		And "Saved reports" should have option "saved test report"
 		When I select "saved test report"
-		Then "objects" should have option "WindowsServers"
-		When I click "Delete" and confirm popup
+		And I click "Delete" and confirm popup
 		# Test available first, to force capybara to wait for page reload
 		Then "objects_tmp" should have option "WindowsServers"
 		And "Saved reports" shouldn't have option "saved test report"

--- a/features/sla.feature
+++ b/features/sla.feature
@@ -527,8 +527,10 @@ Feature: SLA reports
 		Then I should see "Saved reports"
 		And "Saved reports" should have option "saved test report"
 		When I select "saved test report"
+		And I wait for 10 seconds
 		Then "objects" should have option "WindowsServers"
 		When I click "Delete" and confirm popup
+		And I wait for 10 seconds
 		# Test available first, to force capybara to wait for page reload
 		Then "objects_tmp" should have option "WindowsServers"
 		And "Saved reports" shouldn't have option "saved test report"

--- a/features/sla.feature
+++ b/features/sla.feature
@@ -527,10 +527,8 @@ Feature: SLA reports
 		Then I should see "Saved reports"
 		And "Saved reports" should have option "saved test report"
 		When I select "saved test report"
-		And I wait for 10 seconds
 		Then "objects" should have option "WindowsServers"
 		When I click "Delete" and confirm popup
-		And I wait for 10 seconds
 		# Test available first, to force capybara to wait for page reload
 		Then "objects_tmp" should have option "WindowsServers"
 		And "Saved reports" shouldn't have option "saved test report"

--- a/features/summary.feature
+++ b/features/summary.feature
@@ -829,7 +829,6 @@ Feature: Summary reports
 		And I hover over the "Summary" menu
 		When I click "Create Summary Report"
 		Then I should see "Saved reports"
-		And "Saved reports" should have option "saved test report"
 		When I select "saved test report"
 		Then "objects" should have option "LinuxServers"
 		When I click "Delete" and confirm popup

--- a/modules/monitoring/helpers/pnp.php
+++ b/modules/monitoring/helpers/pnp.php
@@ -131,6 +131,6 @@ class pnp
 		} else {
 			$service = '_HOST_';
 		}
-		return $base . "/graph?host=$host&srv=$service";
+		return rtrim($base, '/') . "/graph?host=$host&srv=$service";
 	}
 }

--- a/modules/reports/views/reports/header.php
+++ b/modules/reports/views/reports/header.php
@@ -2,7 +2,7 @@
 	<div id="link_container" class="form-dropdown"></div>
 	<div id="save_report_form" class="form-dropdown">
 	<?php
-		echo form::open(url::base(true).Router::$controller."/save");
+		echo form::open(Router::$controller.'/save');
 		$report_name = $options['report_name'];
 		unset($options['report_name']);
 		echo $options->as_form();

--- a/modules/reports/views/summary/options.php
+++ b/modules/reports/views/summary/options.php
@@ -1,5 +1,5 @@
 <?php defined('SYSPATH') OR die('No direct access allowed.');
-echo form::open(url::base(true) . 'summary/generate', array('class' => 'report_form'), array('report_id' => $options['report_id']));
+echo form::open('summary/generate', array('class' => 'report_form'), array('report_id' => $options['report_id']));
 ?>
 	<div class="standard setup-table">
 		<table class="setup-tbl report_block auto_width">
@@ -30,7 +30,7 @@ echo form::open(url::base(true) . 'summary/generate', array('class' => 'report_f
 	</div>
 <?php echo form::close();
 
-echo form::open(url::base(true) . 'summary/generate', array('class' => 'report_form'), array('report_id' => $options['report_id']));
+echo form::open('summary/generate', array('class' => 'report_form'), array('report_id' => $options['report_id']));
 ?>
 	<div class="custom setup-table">
 		<?php echo new View('reports/objselector'); ?>

--- a/op5build/monitor-ninja.spec
+++ b/op5build/monitor-ninja.spec
@@ -170,14 +170,6 @@ done
 
 install -D -m 755 install_scripts/nacoma_hooks.py %{buildroot}%{nacoma_hooks_path}/ninja_hooks.py
 install -D op5build/libexec/op5_scheduled_reports.py %buildroot%base_prefix/libexec/op5_scheduled_reports.py
-%py_byte_compile %{__python3} %{buildroot}%{nacoma_hooks_path}/
-%py_byte_compile %{__python3} %{buildroot}%{base_prefix}/libexec/
-
-# brp-mangle-shebangs still runs after install; rewrites env python3 to 3.9.
-# Set shebangs to Python 3.12 before that step.
-%py3_shebang_fix -pni "%{__python3} %{py3_shbang_opts}" \
-	%{buildroot}%{nacoma_hooks_path}/ninja_hooks.py \
-	%{buildroot}%{base_prefix}/libexec/op5_scheduled_reports.py
 
 install -d %buildroot%_unitdir
 install -D -m 644 -t %buildroot%_unitdir op5build/systemd/*.{service,timer}
@@ -188,6 +180,19 @@ install -D -m 644 op5build/php-ninja-tests.ini %buildroot%_sysconfdir/php.d/52-n
 
 install -D test/configs/kohana-configs/exception.php %buildroot%prefix/application/config/custom/exception.php
 rm %buildroot%prefix/test/configs/kohana-configs/exception.php
+
+%py_byte_compile %{__python3} %{buildroot}%{nacoma_hooks_path}/
+%py_byte_compile %{__python3} %{buildroot}%{base_prefix}/libexec/
+%py_byte_compile %{__python3} %{buildroot}%prefix/install_scripts/
+%py_byte_compile %{__python3} %{buildroot}%prefix/test/tools/
+
+# brp-mangle-shebangs still runs after install; rewrites env python3 to 3.9.
+# Set shebangs to Python 3.12 before that step.
+%py3_shebang_fix -pni "%{__python3} %{py3_shbang_opts}" \
+	%{buildroot}%{nacoma_hooks_path} \
+	%{buildroot}%{base_prefix}/libexec \
+	%{buildroot}%prefix/install_scripts \
+	%{buildroot}%prefix/test/tools
 
 %post
 # Verify that mysql-server is installed and running before executing sql scripts

--- a/op5build/monitor-ninja.spec
+++ b/op5build/monitor-ninja.spec
@@ -142,7 +142,6 @@ for d in op5build monitor-ninja.spec ninja.doxy \
 do
 	rm -rf %buildroot%prefix/$d
 done
-rm -f %buildroot%prefix/install_scripts/nacoma_hooks.py
 
 sed -i "s/\(IN_PRODUCTION', \)FALSE/\1TRUE/" \
 	%buildroot%prefix/index.php
@@ -171,6 +170,14 @@ done
 
 install -D -m 755 install_scripts/nacoma_hooks.py %{buildroot}%{nacoma_hooks_path}/ninja_hooks.py
 install -D op5build/libexec/op5_scheduled_reports.py %buildroot%base_prefix/libexec/op5_scheduled_reports.py
+%py_byte_compile %{__python3} %{buildroot}%{nacoma_hooks_path}/
+%py_byte_compile %{__python3} %{buildroot}%{base_prefix}/libexec/
+
+# brp-mangle-shebangs still runs after install; rewrites env python3 to 3.9.
+# Set shebangs to Python 3.12 before that step.
+%py3_shebang_fix -pni "%{__python3} %{py3_shbang_opts}" \
+	%{buildroot}%{nacoma_hooks_path}/ninja_hooks.py \
+	%{buildroot}%{base_prefix}/libexec/op5_scheduled_reports.py
 
 install -d %buildroot%_unitdir
 install -D -m 644 -t %buildroot%_unitdir op5build/systemd/*.{service,timer}
@@ -181,23 +188,6 @@ install -D -m 644 op5build/php-ninja-tests.ini %buildroot%_sysconfdir/php.d/52-n
 
 install -D test/configs/kohana-configs/exception.php %buildroot%prefix/application/config/custom/exception.php
 rm %buildroot%prefix/test/configs/kohana-configs/exception.php
-
-# brp-mangle-shebangs still runs after install;
-# Set shebangs to Python 3.12, normalize, then byte-compile final sources.
-%py3_shebang_fix \
-	%{buildroot}%{nacoma_hooks_path}/ninja_hooks.py \
-	%{buildroot}%{base_prefix}/libexec/op5_scheduled_reports.py \
-	%{buildroot}%prefix/test/tools
-# pathfix writes "#! /path" (space after #!); normalize to "#!/path"
-sed -i '1s/^#! \//#!\//' \
-	%{buildroot}%{nacoma_hooks_path}/ninja_hooks.py \
-	%{buildroot}%{base_prefix}/libexec/op5_scheduled_reports.py
-find %{buildroot}%prefix/test/tools \
-	-name '*.py' -exec grep -Il '^#! ' {} + 2>/dev/null \
-	| while read -r f; do sed -i '1s/^#! \//#!\//' "$f"; done
-%py_byte_compile %{__python3} %{buildroot}%{nacoma_hooks_path}/ninja_hooks.py
-%py_byte_compile %{__python3} %{buildroot}%{base_prefix}/libexec/op5_scheduled_reports.py
-%py_byte_compile %{__python3} %{buildroot}%prefix/test/tools/
 
 %post
 # Verify that mysql-server is installed and running before executing sql scripts
@@ -240,7 +230,6 @@ fi
 
 %files
 %license ASL2.txt
-%pycached %{nacoma_hooks_path}/ninja_hooks.py
 %base_prefix/*
 %_unitdir/*
 %attr(-,root,%daemon_group) %_sysconfdir/%{httpconfdir}/monitor-ninja.conf

--- a/op5build/monitor-ninja.spec
+++ b/op5build/monitor-ninja.spec
@@ -142,6 +142,7 @@ for d in op5build monitor-ninja.spec ninja.doxy \
 do
 	rm -rf %buildroot%prefix/$d
 done
+rm -f %buildroot%prefix/install_scripts/nacoma_hooks.py
 
 sed -i "s/\(IN_PRODUCTION', \)FALSE/\1TRUE/" \
 	%buildroot%prefix/index.php
@@ -181,18 +182,22 @@ install -D -m 644 op5build/php-ninja-tests.ini %buildroot%_sysconfdir/php.d/52-n
 install -D test/configs/kohana-configs/exception.php %buildroot%prefix/application/config/custom/exception.php
 rm %buildroot%prefix/test/configs/kohana-configs/exception.php
 
-%py_byte_compile %{__python3} %{buildroot}%{nacoma_hooks_path}/
-%py_byte_compile %{__python3} %{buildroot}%{base_prefix}/libexec/
-%py_byte_compile %{__python3} %{buildroot}%prefix/install_scripts/
-%py_byte_compile %{__python3} %{buildroot}%prefix/test/tools/
-
-# brp-mangle-shebangs still runs after install; rewrites env python3 to 3.9.
-# Set shebangs to Python 3.12 before that step.
-%py3_shebang_fix -pni "%{__python3} %{py3_shbang_opts}" \
-	%{buildroot}%{nacoma_hooks_path} \
-	%{buildroot}%{base_prefix}/libexec \
-	%{buildroot}%prefix/install_scripts \
+# brp-mangle-shebangs still runs after install;
+# Set shebangs to Python 3.12, normalize, then byte-compile final sources.
+%py3_shebang_fix \
+	%{buildroot}%{nacoma_hooks_path}/ninja_hooks.py \
+	%{buildroot}%{base_prefix}/libexec/op5_scheduled_reports.py \
 	%{buildroot}%prefix/test/tools
+# pathfix writes "#! /path" (space after #!); normalize to "#!/path"
+sed -i '1s/^#! \//#!\//' \
+	%{buildroot}%{nacoma_hooks_path}/ninja_hooks.py \
+	%{buildroot}%{base_prefix}/libexec/op5_scheduled_reports.py
+find %{buildroot}%prefix/test/tools \
+	-name '*.py' -exec grep -Il '^#! ' {} + 2>/dev/null \
+	| while read -r f; do sed -i '1s/^#! \//#!\//' "$f"; done
+%py_byte_compile %{__python3} %{buildroot}%{nacoma_hooks_path}/ninja_hooks.py
+%py_byte_compile %{__python3} %{buildroot}%{base_prefix}/libexec/op5_scheduled_reports.py
+%py_byte_compile %{__python3} %{buildroot}%prefix/test/tools/
 
 %post
 # Verify that mysql-server is installed and running before executing sql scripts
@@ -235,6 +240,7 @@ fi
 
 %files
 %license ASL2.txt
+%pycached %{nacoma_hooks_path}/ninja_hooks.py
 %base_prefix/*
 %_unitdir/*
 %attr(-,root,%daemon_group) %_sysconfdir/%{httpconfdir}/monitor-ninja.conf

--- a/system/helpers/form.php
+++ b/system/helpers/form.php
@@ -44,7 +44,7 @@ class form {
 			// Works with open(), open('') and open(null)
 			$action = url::site(Router::$complete_uri);
 		}
-		elseif (strpos($action, '://') === FALSE)
+		elseif (strpos($action, '://') === FALSE && (isset($action[0]) && $action[0] !== '/'))
 		{
 			// Make the action URI into a URL
 			$action = url::site($action);


### PR DESCRIPTION
This commit normalizes PNP graph URLs by stripping 
a trailing slash on the base. 
This also tighten delete-saved-report steps, so they don’t 
assert object options that aren’t needed for the delete flow.

Signed-off-by: Eunice Remoquillo <eremoquillo@itrsgroup.com>
Co-authored-by: Gian Ilagan <gilagan@itrsgroup.com>